### PR TITLE
fix: correct invalid skill name fields to kebab-case

### DIFF
--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Command Development
+name: command-development
 description: This skill should be used when the user asks to "create a slash command", "add a command", "write a custom command", "define command arguments", "use command frontmatter", "organize commands", "create command with file references", "interactive command", "use AskUserQuestion in command", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Hook Development
+name: hook-development
 description: This skill should be used when the user asks to "create a hook", "add a PreToolUse/PostToolUse/Stop hook", "validate tool use", "implement prompt-based hooks", "use ${CLAUDE_PLUGIN_ROOT}", "set up event-driven automation", "block dangerous commands", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: MCP Integration
+name: mcp-integration
 description: This skill should be used when the user asks to "add MCP server", "integrate MCP", "configure MCP in plugin", "use .mcp.json", "set up Model Context Protocol", "connect external service", mentions "${CLAUDE_PLUGIN_ROOT} with MCP", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Plugin Settings
+name: plugin-settings
 description: This skill should be used when the user asks about "plugin settings", "store plugin configuration", "user-configurable plugin", ".local.md files", "plugin state files", "read YAML frontmatter", "per-project plugin settings", or wants to make plugin behavior configurable. Documents the .claude/plugin-name.local.md pattern for storing plugin-specific configuration with YAML frontmatter and markdown content.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Plugin Structure
+name: plugin-structure
 description: This skill should be used when the user asks to "create a plugin", "scaffold a plugin", "understand plugin structure", "organize plugin components", "set up plugin.json", "use ${CLAUDE_PLUGIN_ROOT}", "add commands/agents/skills/hooks", "configure auto-discovery", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Skill Development
+name: skill-development
 description: This skill should be used when the user asks to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins.
 version: 0.1.0
 ---


### PR DESCRIPTION
## Summary

- Fix 6 skill SKILL.md files with invalid `name` fields that used Title Case instead of kebab-case
- Update names to match directory names exactly per official Claude Code skills documentation

## Problem

Fixes #1

Per the [official Claude Code skills documentation](https://code.claude.com/docs/en/skills.md):
> **Name**: Must use lowercase letters, numbers, and hyphens only (max 64 characters)

Six skills violated this specification with Title Case names.

## Solution

Changed the `name` field in each affected SKILL.md to kebab-case:

| Skill Directory | Before | After |
|-----------------|--------|-------|
| `command-development` | `Command Development` | `command-development` |
| `mcp-integration` | `MCP Integration` | `mcp-integration` |
| `plugin-structure` | `Plugin Structure` | `plugin-structure` |
| `skill-development` | `Skill Development` | `skill-development` |
| `plugin-settings` | `Plugin Settings` | `plugin-settings` |
| `hook-development` | `Hook Development` | `hook-development` |

### Alternatives Considered

None - this is a straightforward spec compliance fix. The correct names are the directory names themselves.

## Changes

- `plugins/plugin-dev/skills/command-development/SKILL.md`: name field updated
- `plugins/plugin-dev/skills/mcp-integration/SKILL.md`: name field updated
- `plugins/plugin-dev/skills/plugin-structure/SKILL.md`: name field updated
- `plugins/plugin-dev/skills/skill-development/SKILL.md`: name field updated
- `plugins/plugin-dev/skills/plugin-settings/SKILL.md`: name field updated
- `plugins/plugin-dev/skills/hook-development/SKILL.md`: name field updated

## Testing

- [x] All 6 affected skill `name` fields updated to kebab-case
- [x] Names match their directory names exactly
- [x] No other changes to SKILL.md files
- [x] Linting passes (`markdownlint`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)