### PR TITLE
feat: enhance skill-development description with stronger triggers

### DIFF
--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-development
-description: This skill should be used when the user asks to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins.
+description: This skill should be used when the user asks to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", "SKILL.md format", "skill frontmatter", "skill triggers", "trigger phrases for skills", "progressive disclosure", "skill references folder", "skill examples folder", "validate skill", or needs guidance on skill structure, file organization, writing style, or skill development best practices for Claude Code plugins.
 version: 0.1.0
 ---
 


### PR DESCRIPTION
## Summary

Enhance the skill-development skill description with stronger trigger phrases to improve Claude's ability to recognize when this skill should be activated.

## Problem

Fixes #3

The skill-development skill had only 5 trigger phrases, making it the weakest description among the 7 plugin-dev skills. As a meta-skill teaching description best practices, it should exemplify those practices.

## Solution

Added 8 new trigger phrases following the gold-standard pattern from hook-development:

**New trigger phrases:**
- `"SKILL.md format"` - file reference
- `"skill frontmatter"` - technical term
- `"skill triggers"` - technical term
- `"trigger phrases for skills"` - concept
- `"progressive disclosure"` - already existed, now quoted
- `"skill references folder"` - folder reference
- `"skill examples folder"` - folder reference
- `"validate skill"` - action phrase

**Also expanded keywords:**
- Added: file organization, writing style

### Alternatives Considered

- **Minimal enhancement**: Only add 3-4 phrases. Rejected because the issue requested at least 10 total.
- **Maximum enhancement**: Add 20+ phrases. Rejected to avoid cluttering the description and stay well under the 1024 char limit.

## Changes

- `plugins/plugin-dev/skills/skill-development/SKILL.md`: Updated description frontmatter field

## Acceptance Criteria

- [x] Description includes at least 10 specific trigger phrases (now has 13)
- [x] Covers file/folder references (`SKILL.md`, `references/`, `examples/`)
- [x] Includes technical terms (frontmatter, triggers, progressive disclosure)
- [x] Maintains third-person format ("This skill should be used when...")
- [x] Stays under 1024 character limit (484 chars)

## Testing

- [x] Markdownlint passes
- [x] Character count verified (484 < 1024)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)