### PR TITLE
refactor: convert passive voice to imperative form in skill content

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -8,7 +8,7 @@ version: 0.1.0
 
 ## Overview
 
-Agents are autonomous subprocesses that handle complex, multi-step tasks independently. Understanding agent structure, triggering conditions, and system prompt design enables creating powerful autonomous capabilities.
+Agents are autonomous subprocesses that handle complex, multi-step tasks independently. Master agent structure, triggering conditions, and system prompt design to create powerful autonomous capabilities.
 
 **Key concepts:**
 - Agents are FOR autonomous work, commands are FOR user-initiated actions

--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -8,7 +8,7 @@ version: 0.1.0
 
 ## Overview
 
-Slash commands are frequently-used prompts defined as Markdown files that Claude executes during interactive sessions. Understanding command structure, frontmatter options, and dynamic features enables creating powerful, reusable workflows.
+Slash commands are frequently-used prompts defined as Markdown files that Claude executes during interactive sessions. Master command structure, frontmatter options, and dynamic features to create powerful, reusable workflows.
 
 **Key concepts:**
 

--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -293,7 +293,7 @@ Provide template in plugin README:
 ```markdown
 ## Configuration
 
-Create `.claude/my-plugin.local.md` in your project:
+Create `.claude/my-plugin.local.md` in the project:
 
 \`\`\`markdown
 ---
@@ -304,7 +304,7 @@ max_retries: 3
 
 # Plugin Configuration
 
-Your settings are active.
+Settings are active.
 \`\`\`
 
 After creating or editing, restart Claude Code for changes to take effect.
@@ -368,7 +368,7 @@ fi
 
 **Important:** Settings changes require Claude Code restart.
 
-Document in your README:
+Document in the plugin README:
 
 ```markdown
 ## Changing Settings

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -8,7 +8,7 @@ version: 0.1.0
 
 ## Overview
 
-Claude Code plugins follow a standardized directory structure with automatic component discovery. Understanding this structure enables creating well-organized, maintainable plugins that integrate seamlessly with Claude Code.
+Claude Code plugins follow a standardized directory structure with automatic component discovery. Master this structure to create well-organized, maintainable plugins that integrate seamlessly with Claude Code.
 
 **Key concepts:**
 


### PR DESCRIPTION
## Summary
- Convert "Understanding X enables creating Y" passive constructions to imperative "Master X to create Y" form
- Replace second-person possessive "your" with definite article "the" in template examples
- Ensure consistent instructional voice across all skill content

## Problem
Fixes #4

Per the skill-development best practices, SKILL.md body content should use **imperative/infinitive form**, not passive voice or second person. Several skills contained passive constructions and second-person pronouns that needed conversion.

## Solution
Applied consistent imperative voice conversions following these patterns:

| Pattern | Before | After |
|---------|--------|-------|
| Passive gerund | "Understanding X enables creating Y" | "Master X to create Y" |
| Second-person possessive | "in your project" | "in the project" |
| Second-person possessive | "Your settings" | "Settings" |

## Changes
- `agent-development/SKILL.md`: Line 11 - passive to imperative
- `command-development/SKILL.md`: Line 11 - passive to imperative
- `plugin-structure/SKILL.md`: Line 11 - passive to imperative
- `plugin-settings/SKILL.md`: Lines 296, 307, 371 - second-person to definite article

## Testing
- [x] All changes follow imperative/infinitive form
- [x] Markdown linting passes
- [x] Skills read naturally with consistent voice
- [x] No second-person pronouns in instructional content

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)