### PR TITLE
feat: strengthen agent-development skill trigger phrases

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-development
-description: This skill should be used when the user asks to "create an agent", "add an agent", "write a subagent", "agent frontmatter", "when to use description", "agent examples", "agent tools", "agent colors", "autonomous agent", or needs guidance on agent structure, system prompts, triggering conditions, or agent development best practices for Claude Code plugins.
+description: This skill should be used when the user asks to "create an agent", "add an agent", "write a subagent", "design an agent for [task]", "how do I write agent descriptions", "what are the agent frontmatter fields", "validate my agent", "test agent triggering", "how to restrict agent tools", "what colors can agents use", "autonomous agent", or needs guidance on agent structure, system prompts, triggering conditions, or agent development best practices for Claude Code plugins.
 version: 0.1.0
 ---
 


### PR DESCRIPTION
## Summary

Update the `agent-development` skill description to use natural query-style trigger phrases instead of fragments for improved skill discovery and activation.

## Problem

Fixes #10

The current trigger phrases include fragments that don't match how users naturally ask questions:
- `"agent frontmatter"` - fragment, not a question
- `"agent tools"` - fragment
- `"agent colors"` - fragment

## Solution

Replace fragments with natural user queries that improve skill triggering:
- `"agent frontmatter"` → `"what are the agent frontmatter fields"`
- `"agent tools"` → `"how to restrict agent tools"`
- `"agent colors"` → `"what colors can agents use"`

Added new trigger phrases covering common user intents:
- `"design an agent for [task]"`
- `"how do I write agent descriptions"`
- `"validate my agent"`
- `"test agent triggering"`

## Changes

- `plugins/plugin-dev/skills/agent-development/SKILL.md`: Updated description field with natural query-style trigger phrases

## Testing

- [x] Linting passes
- [x] Description follows established patterns from other skills

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)