### PR TITLE
feat: add component comparison section to agent-development skill

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -17,6 +17,35 @@ Agents are autonomous subprocesses that handle complex, multi-step tasks indepen
 - System prompt defines agent behavior
 - Model and color customization
 
+## When to Use Agents vs Commands vs Skills
+
+| Component | Best For | Triggering | Example Use Case |
+|-----------|----------|------------|------------------|
+| **Agents** | Autonomous multi-step tasks | Proactive or description-matched | Code review after implementation |
+| **Commands** | User-initiated actions | Explicit `/command` invocation | `/deploy production` |
+| **Skills** | Knowledge and guidance | Model-invoked based on context | Domain expertise for PDF processing |
+
+### Choose Agents When
+
+- Task requires autonomous, multi-step execution
+- Proactive triggering after certain events is desired
+- Specialized subprocess with focused tools needed
+- Work should happen in the background or as a subagent
+
+### Choose Commands When
+
+- User should explicitly trigger the action
+- Task has clear start/end with specific inputs
+- Action should not happen automatically
+- Workflow requires user confirmation at each step
+
+### Choose Skills When
+
+- Providing knowledge or procedural guidance
+- Extending Claude's domain expertise
+- No autonomous execution needed
+- Information should be available contextually on-demand
+
 ## Agent File Structure
 
 ### Complete Format


### PR DESCRIPTION
## Summary

- Add comparison table showing when to use agents vs commands vs skills
- Add decision criteria sections for each component type
- Help users choose the right component for their use case

## Problem

Fixes #11

Users may not know which plugin component is appropriate for their use case. The agent-development skill explains how to create agents but doesn't help users understand WHEN to use agents versus commands or skills.

## Solution

Added a new "When to Use Agents vs Commands vs Skills" section after the Overview in the agent-development skill. This includes:

- **Comparison table** - Quick reference showing component, best use case, triggering method, and example
- **Choose Agents When** - Criteria for selecting agents
- **Choose Commands When** - Criteria for selecting commands  
- **Choose Skills When** - Criteria for selecting skills

### Alternatives Considered

1. **Separate reference file** - Could have added as `references/component-comparison.md` but decided inline was better for discoverability since this is foundational knowledge users need early
2. **Full detailed guide** - Could have added more extensive examples, but kept it concise to match the skill's lean style

## Changes

- `plugins/plugin-dev/skills/agent-development/SKILL.md`: Added 29-line comparison section after Overview

## Testing

- [x] Linting passes (`markdownlint`)
- [x] Content matches acceptance criteria from issue

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)