### PR TITLE
docs: remove invalid version field from skill frontmatter

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: agent-development
 description: This skill should be used when the user asks to "create an agent", "add an agent", "write a subagent", "design an agent for [task]", "how do I write agent descriptions", "what are the agent frontmatter fields", "validate my agent", "test agent triggering", "how to restrict agent tools", "what colors can agents use", "autonomous agent", or needs guidance on agent structure, system prompts, triggering conditions, or agent development best practices for Claude Code plugins.
-version: 0.1.0
 ---
 
 # Agent Development for Claude Code Plugins

--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: command-development
 description: This skill should be used when the user asks to "create a slash command", "add a command", "write a custom command", "define command arguments", "use command frontmatter", "organize commands", "create command with file references", "interactive command", "use AskUserQuestion in command", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.
-version: 0.1.0
 ---
 
 # Command Development for Claude Code

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: hook-development
 description: This skill should be used when the user asks to "create a hook", "add a PreToolUse/PostToolUse/Stop hook", "validate tool use", "implement prompt-based hooks", "use ${CLAUDE_PLUGIN_ROOT}", "set up event-driven automation", "block dangerous commands", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.
-version: 0.1.0
 ---
 
 # Hook Development for Claude Code Plugins

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mcp-integration
 description: This skill should be used when the user asks to "add MCP server", "integrate MCP", "configure MCP in plugin", "use .mcp.json", "set up Model Context Protocol", "connect external service", mentions "${CLAUDE_PLUGIN_ROOT} with MCP", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.
-version: 0.1.0
 ---
 
 # MCP Integration for Claude Code Plugins

--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plugin-settings
 description: This skill should be used when the user asks about "plugin settings", "store plugin configuration", "user-configurable plugin", ".local.md files", "plugin state files", "read YAML frontmatter", "per-project plugin settings", or wants to make plugin behavior configurable. Documents the .claude/plugin-name.local.md pattern for storing plugin-specific configuration with YAML frontmatter and markdown content.
-version: 0.1.0
 ---
 
 # Plugin Settings Pattern for Claude Code Plugins

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plugin-structure
 description: This skill should be used when the user asks to "create a plugin", "scaffold a plugin", "understand plugin structure", "organize plugin components", "set up plugin.json", "use ${CLAUDE_PLUGIN_ROOT}", "add commands/agents/skills/hooks", "configure auto-discovery", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.
-version: 0.1.0
 ---
 
 # Plugin Structure for Claude Code

--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: skill-development
 description: This skill should be used when the user asks to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", "SKILL.md format", "skill frontmatter", "skill triggers", "trigger phrases for skills", "progressive disclosure", "skill references folder", "skill examples folder", "validate skill", or needs guidance on skill structure, file organization, writing style, or skill development best practices for Claude Code plugins.
-version: 0.1.0
 ---
 
 # Skill Development for Claude Code Plugins

--- a/plugins/plugin-dev/skills/skill-development/references/skill-creation-workflow.md
+++ b/plugins/plugin-dev/skills/skill-development/references/skill-creation-workflow.md
@@ -82,7 +82,6 @@ Also, delete any example files and directories not needed for the skill. Create 
 ---
 name: Skill Name
 description: This skill should be used when the user asks to "specific phrase 1", "specific phrase 2", "specific phrase 3". Include exact phrases users would say that should trigger this skill. Be concrete and specific.
-version: 0.1.0
 ---
 ```
 


### PR DESCRIPTION
## Summary
- Remove `version` field from all 7 skill SKILL.md frontmatter
- Update skill-creation-workflow.md template to exclude version field

## Problem
Fixes #12

The `version` field was present in skill frontmatter but is not a valid field according to official Claude Code documentation. Valid skill frontmatter fields are:
- `name` (required)
- `description` (required)
- `allowed-tools` (optional)

## Solution
Remove `version: 0.1.0` from all skill files since it's not a recognized field. This aligns the plugin's skills with the official specification.

### Alternatives Considered
- **Document as optional field**: Rejected because official docs explicitly don't support it
- **Keep and ignore**: Rejected because it sets a bad example for plugin developers

## Changes
- `plugins/plugin-dev/skills/*/SKILL.md` (7 files): Remove `version: 0.1.0` line
- `plugins/plugin-dev/skills/skill-development/references/skill-creation-workflow.md`: Remove version from template example

## Testing
- [x] All modified files pass markdownlint
- [x] Frontmatter structure remains valid (name + description)
- [x] No other references to skill version field in codebase

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)