### PR TITLE
feat(agent-development): add cross-references to related skills

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -24,6 +24,8 @@ Agents are autonomous subprocesses that handle complex, multi-step tasks indepen
 | **Commands** | User-initiated actions | Explicit `/command` invocation | `/deploy production` |
 | **Skills** | Knowledge and guidance | Model-invoked based on context | Domain expertise for PDF processing |
 
+> **See also:** For command development, load the `command-development` skill. For skill development, load the `skill-development` skill.
+
 ### Choose Agents When
 
 - Task requires autonomous, multi-step execution
@@ -38,12 +40,16 @@ Agents are autonomous subprocesses that handle complex, multi-step tasks indepen
 - Action should not happen automatically
 - Workflow requires user confirmation at each step
 
+For command development guidance, see the `command-development` skill.
+
 ### Choose Skills When
 
 - Providing knowledge or procedural guidance
 - Extending Claude's domain expertise
 - No autonomous execution needed
 - Information should be available contextually on-demand
+
+For skill development guidance, see the `skill-development` skill.
 
 ## Agent File Structure
 


### PR DESCRIPTION
## Summary
- Add blockquote after comparison table linking to `command-development` and `skill-development` skills
- Add cross-reference after "Choose Commands When" section
- Add cross-reference after "Choose Skills When" section

## Problem
Fixes #18

Users reading the agent-development skill's comparison section (agents vs commands vs skills) had no direct links to learn more about developing those other component types.

## Solution
Added three cross-references to help users discover related skills:
1. A blockquote after the comparison table: "See also: For command development, load the `command-development` skill. For skill development, load the `skill-development` skill."
2. After "Choose Commands When": reference to `command-development` skill
3. After "Choose Skills When": reference to `skill-development` skill

### Alternatives Considered
- Adding hyperlinks: Not applicable since skills are invoked by name, not URLs
- Adding to a separate "Related Skills" section: Would be less discoverable; inline references are more contextual

## Changes
- `plugins/plugin-dev/skills/agent-development/SKILL.md`: Added 3 cross-references (6 lines)

## Testing
- [x] Word count verified: 1,672 words (within 1,500-2,000 ideal range)
- [x] Linting passes: `markdownlint` shows no issues
- [x] Cross-referenced skills exist and are valid

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)