### PR TITLE
docs(agent-development): improve visibility of tools vs allowed-tools disambiguation

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -16,6 +16,8 @@ Agents are autonomous subprocesses that handle complex, multi-step tasks indepen
 - System prompt defines agent behavior
 - Model and color customization
 
+> **⚠️ Field Name Difference:** Agents use `tools` to restrict tool access. Skills use `allowed-tools` for the same purpose. Don't confuse these when switching between component types.
+
 ## When to Use Agents vs Commands vs Skills
 
 | Component | Best For | Triggering | Example Use Case |
@@ -198,6 +200,8 @@ tools: ["Read", "Write", "Grep", "Bash"]
 - Code generation: `["Read", "Write", "Grep"]`
 - Testing: `["Read", "Bash", "Grep"]`
 - Full access: Omit field or use `["*"]`
+
+> **Important:** Agents use `tools` while Skills use `allowed-tools`. The field names differ between component types. For skill tool restrictions, see the `skill-development` skill.
 
 ## System Prompt Design
 


### PR DESCRIPTION
## Summary
- Added prominent callout in Overview section for early visibility
- Added contextual note in tools field section with cross-reference to skill-development skill
- Implements Option C from issue (both locations)

## Problem
Fixes #24

The important distinction between `tools` (agents) and `allowed-tools` (skills) was buried at line ~385 in the Quick Reference section, making it easy to miss when switching between component types.

## Solution
Added the disambiguation in two strategic locations:

1. **Overview section** (line 19) - Early visibility with warning emoji callout
2. **tools field section** (line 204) - Contextual help when users are configuring tool restrictions, includes cross-reference to skill-development skill

This dual placement ensures users see the warning whether they're scanning the document from the top or jumping directly to the tools field documentation.

### Alternatives Considered
- **Option A (tools field only)**: Would miss users scanning from top
- **Option B (Overview only)**: Would miss users jumping to tools field
- **Option C (both)**: Selected - ensures visibility in both contexts

## Changes
- `plugins/plugin-dev/skills/agent-development/SKILL.md`: Added 2 callout boxes

## Testing
- [x] Markdownlint passes
- [x] Both callouts render correctly in markdown
- [x] Cross-reference to skill-development skill included

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)