### PR TITLE
docs(agent-development): add minimal working example after Overview

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -18,6 +18,40 @@ Agents are autonomous subprocesses that handle complex, multi-step tasks indepen
 
 > **⚠️ Field Name Difference:** Agents use `tools` to restrict tool access. Skills use `allowed-tools` for the same purpose. Don't confuse these when switching between component types.
 
+## Quick Start
+
+Minimal working agent (copy-paste ready):
+
+```markdown
+---
+name: my-reviewer
+description: Use this agent when the user asks to review code. Examples:
+
+<example>
+Context: User wrote new code
+user: "Review my changes"
+assistant: "I'll use the my-reviewer agent to analyze the code."
+<commentary>
+Code review request triggers the agent.
+</commentary>
+</example>
+
+model: inherit
+color: blue
+---
+
+You are a code reviewer. Analyze code for issues and provide feedback.
+
+**Process:**
+1. Read the code
+2. Identify issues
+3. Provide recommendations
+
+**Output:** Summary with file:line references for each finding.
+```
+
+For complete format with all options, see [Agent File Structure](#agent-file-structure).
+
 ## When to Use Agents vs Commands vs Skills
 
 | Component | Best For | Triggering | Example Use Case |
@@ -164,7 +198,9 @@ Which model the agent should use.
 - `sonnet` - Balanced performance; most use cases (default recommendation)
 - `opus` - Complex reasoning; detailed analysis; highest capability needed
 
-**Recommendation:** Use `inherit` unless agent needs specific model capabilities.
+**Recommendation:** Use `inherit` (recommended default) unless the agent specifically needs:
+- `haiku` for fast, cost-sensitive operations
+- `opus` for complex reasoning requiring maximum capability
 
 ### color (required)
 


### PR DESCRIPTION
## Summary

Adds a Quick Start section with a minimal, copy-paste ready agent example to improve onboarding for new users. Also enhances the model field documentation to more clearly emphasize `inherit` as the recommended default.

## Problem

Fixes #25

The first example users see is the "Complete Format" which includes all frontmatter fields with explanations. New users often want a quick-start template that "just works" before diving into all the options.

## Solution

Added a **Quick Start** section immediately after Overview with:
- ~25-line minimal working agent example
- Complete and copy-paste ready
- Link to detailed Agent File Structure section for more options

Also improved the `model` field recommendation:
```markdown
**Recommendation:** Use `inherit` (recommended default) unless the agent specifically needs:
- `haiku` for fast, cost-sensitive operations
- `opus` for complex reasoning requiring maximum capability
```

### Alternatives Considered

- Putting Quick Start at the end: Rejected because new users read top-to-bottom
- Making the Complete Format example smaller: Would lose important context for advanced users

## Changes

- `plugins/plugin-dev/skills/agent-development/SKILL.md`: Added Quick Start section, improved model recommendation

## Testing

- [x] Markdownlint passes
- [x] Word count remains under 2,000 (1,891 words)
- [x] Example is complete and valid agent format

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)