### PR TITLE
fix(ci): add permissions block to pr-checks.yml orchestrator

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,15 @@ concurrency:
   group: pr-checks-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Permissions required by reusable workflows
+# Union of: component-validation, version-check, claude-pr-review
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
 jobs:
   # Detect what files changed to determine which checks to run
   changes:


### PR DESCRIPTION
## Summary
- Added required `permissions:` block to `pr-checks.yml` orchestrator workflow
- Enables reusable workflow calls to access necessary GitHub token permissions

## Problem
Fixes #35

The PR Checks orchestrator workflow fails with `startup_failure` because reusable workflows can only access permissions explicitly granted by the calling workflow. Without a `permissions:` block, all permissions default to `none`.

**Error:** "The nested job 'validate' is requesting 'actions: read, issues: write, pull-requests: write, id-token: write', but is only allowed 'actions: none, issues: none, pull-requests: none, id-token: none'."

## Solution
Added a `permissions:` block with the union of all permissions required by:
- `component-validation.yml`
- `version-check.yml`  
- `claude-pr-review.yml`

```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
  id-token: write
  actions: read
```

### Alternatives Considered
- Adding permissions to each job individually - rejected because workflow-level permissions are cleaner and reusable workflows inherit from the caller

## Changes
- `.github/workflows/pr-checks.yml`: Added `permissions:` block after `concurrency:`

## Testing
- [x] actionlint validation passes
- [x] Workflow syntax is valid
- [ ] PR Checks workflow runs successfully (will verify when this PR triggers)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)