### PR TITLE
fix(agent-development): align validate-agent.sh name validation with docs

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -65,8 +65,8 @@ else
   echo "✅ name: $NAME"
 
   # Validate name format
-  if ! [[ "$NAME" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ ]]; then
-    echo "❌ name must start/end with alphanumeric and contain only letters, numbers, hyphens"
+  if ! [[ "$NAME" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$ ]]; then
+    echo "❌ name must start/end with lowercase alphanumeric and contain only lowercase letters, numbers, hyphens"
     ((error_count++))
   fi
 


### PR DESCRIPTION
## Summary

Aligns `validate-agent.sh` name validation regex with documented requirements in SKILL.md, which specifies names should be "lowercase, numbers, hyphens only".

## Problem

Fixes #33

The validation regex allowed uppercase letters (`[a-zA-Z0-9]`) but documentation requires lowercase only. This inconsistency could cause confusion where the validator accepts names like `Code-Reviewer` that don't follow documented conventions.

## Solution

Changed the name validation regex from `[a-zA-Z0-9]` to `[a-z0-9]` and updated the error message to explicitly mention "lowercase" requirement.

### Alternatives Considered

- **Update documentation to allow uppercase**: Rejected because `create-agent-skeleton.sh` already uses lowercase-only validation, so changing docs would create inconsistency with that script.

## Changes

- `plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh`: Updated regex and error message on lines 68-69

## Testing

- [x] shellcheck passes
- [x] Existing agents validate successfully (`agent-creator.md`)
- [x] Uppercase names now correctly rejected with updated error message

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)