### PR TITLE
docs(skill-development): add allowed-tools optional frontmatter documentation

### DIFF
--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -42,6 +42,28 @@ skill-name/
 
 **Metadata Quality:** The `name` and `description` in YAML frontmatter determine when Claude will use the skill. Be specific about what the skill does and when to use it. Use the third-person (e.g. "This skill should be used when..." instead of "Use this skill when...").
 
+#### Optional Frontmatter Fields
+
+##### allowed-tools
+
+Optionally restrict which tools Claude can use when the skill is active:
+
+```yaml
+---
+name: code-reviewer
+description: Review code for best practices...
+allowed-tools: Read, Grep, Glob
+---
+```
+
+Use `allowed-tools` for:
+
+- Read-only skills that shouldn't modify files
+- Security-sensitive workflows
+- Skills with limited scope
+
+When specified, Claude can only use the listed tools without needing permission. If omitted, Claude follows the standard permission model.
+
 #### Bundled Resources (optional)
 
 ##### Scripts (`scripts/`)
@@ -176,6 +198,7 @@ Before finalizing a skill:
 
 - [ ] SKILL.md file exists with valid YAML frontmatter
 - [ ] Frontmatter has `name` and `description` fields
+- [ ] (Optional) `allowed-tools` field if restricting tool access
 - [ ] Markdown body is present and substantial
 - [ ] Referenced files actually exist
 


### PR DESCRIPTION
## Summary

Add documentation for the optional `allowed-tools` frontmatter field that allows skills to restrict which tools Claude can use when the skill is active.

## Problem

Fixes #39

The official Claude Code documentation includes an `allowed-tools` frontmatter field for skills, but the skill-development skill didn't document this optional feature. Users creating skills didn't know about this option for restricting tool access.

## Solution

Added documentation to SKILL.md explaining the `allowed-tools` feature:
- New "Optional Frontmatter Fields" section after "SKILL.md (required)"
- YAML example showing proper syntax
- Use cases (read-only skills, security-sensitive workflows, limited scope)
- Updated validation checklist with optional allowed-tools check

### Alternatives Considered

1. **Add to references file** - Rejected because this is a core frontmatter feature that belongs in the main SKILL.md, not detailed reference material
2. **Just link to official docs** - Rejected because external links may break and doesn't provide enough context

## Changes

- `plugins/plugin-dev/skills/skill-development/SKILL.md`: +23 lines
  - Added "Optional Frontmatter Fields" section with `allowed-tools` documentation
  - Added optional check in validation checklist

## Testing

- [x] Linting passes (markdownlint)
- [x] Documentation follows existing patterns
- [x] Example uses correct YAML syntax

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)