### PR TITLE
docs(skill-development): update validation checklist and clarify reference file purposes

### DIFF
--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -198,6 +198,8 @@ Before finalizing a skill:
 
 - [ ] SKILL.md file exists with valid YAML frontmatter
 - [ ] Frontmatter has `name` and `description` fields
+- [ ] Name uses only lowercase letters, numbers, and hyphens (max 64 chars)
+- [ ] Description is under 1024 characters
 - [ ] (Optional) `allowed-tools` field if restricting tool access
 - [ ] Markdown body is present and substantial
 - [ ] Referenced files actually exist
@@ -297,8 +299,8 @@ Copy-paste ready skill templates in `examples/`:
 
 For detailed guidance, consult:
 
-- **`references/skill-creation-workflow.md`** - Complete step-by-step skill creation process with examples, writing style guide, and common mistakes to avoid
-- **`references/skill-creator-original.md`** - Full original skill-creator methodology
+- **`references/skill-creation-workflow.md`** - Plugin-specific skill creation workflow (recommended for plugin skills)
+- **`references/skill-creator-original.md`** - Original generic skill-creator methodology (includes init/packaging scripts for standalone skills)
 
 ### Study These Skills
 


### PR DESCRIPTION
## Summary

- Adds name format rules (lowercase letters, numbers, hyphens, max 64 chars) to validation checklist
- Adds description length limit (1024 chars) to validation checklist
- Clarifies reference file descriptions to explain when to use each

## Problem

Fixes #41

The skill-development SKILL.md validation checklist was missing format requirements documented in official Claude Code docs. Additionally, the two reference files were listed without explaining when to use each.

## Solution

Updated the validation checklist Structure section to include:
- Name format validation (lowercase letters, numbers, hyphens, max 64 chars)
- Description length check (under 1024 characters)

Updated reference file descriptions to clarify purpose:
- `skill-creation-workflow.md` - Plugin-specific workflow (recommended for plugin skills)
- `skill-creator-original.md` - Generic methodology (includes standalone skill scripts)

## Changes

- `plugins/plugin-dev/skills/skill-development/SKILL.md`: Added 2 checklist items, updated 2 reference descriptions

## Testing

- [x] Markdownlint passes
- [x] Changes match acceptance criteria in issue

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)