### PR TITLE
chore(docs): remove false-positive TODOs from example documentation

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
+++ b/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
@@ -587,9 +587,9 @@ TESTING:
   - Manual test checklist: tests/manual-checklist.md
 
 FUTURE IMPROVEMENTS:
-  - TODO: Add support for TOML format
-  - TODO: Implement parallel processing
-  - TODO: Add progress bar for large files
+  - Add support for TOML format
+  - Implement parallel processing
+  - Add progress bar for large files
 
 RELATED FILES:
   - lib/parser.sh: Shared parsing logic


### PR DESCRIPTION
## Summary

Removes `TODO:` prefixes from example documentation to prevent the weekly maintenance workflow from flagging them as action items.

## Problem

Fixes #51

The weekly maintenance report flagged 3 TODOs in `documentation-patterns.md`, but these were actually part of an example command specification template showing what a "FUTURE IMPROVEMENTS" section might look like—not real action items for the codebase.

## Solution

Removed the `TODO:` prefixes while preserving the FUTURE IMPROVEMENTS section content. This maintains the documentation's purpose (showing a pattern) without triggering false positives in maintenance scans.

### Alternatives Considered

1. **Create issues for the features** - Not appropriate since these are hypothetical examples, not planned features
2. **Exclude the file from TODO scanning** - Would be overly broad and might miss real TODOs
3. **Change to "Planned:" prefix** - Simpler to just remove the prefix entirely

## Changes

- `plugins/plugin-dev/skills/command-development/references/documentation-patterns.md`: Removed `TODO:` prefixes from 3 example items

## Testing

- [x] Verified no TODOs remain in the file
- [x] Linting passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)