### PR TITLE
fix(command-development): remove inconsistent backtick escaping

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md
+++ b/plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md
@@ -393,9 +393,9 @@ description: Commit with pre-commit validation
 allowed-tools: Bash(git:*)
 ---
 
-Stage changes: !\`git add $1\`
+Stage changes: !`git add $1`
 
-Commit changes: !\`git commit -m "$2"\`
+Commit changes: !`git commit -m "$2"`
 
 Note: This commit will trigger the plugin's pre-commit hook for validation.
 Review hook output for any issues.


### PR DESCRIPTION
## Summary

Remove backslash escaping from bash pre-execution syntax examples that were inconsistent with the rest of the documentation file.

## Problem

Fixes #58

Lines 396-398 in `plugin-features-reference.md` used escaped backticks (`!\``) while all other 27 bash pre-execution examples in the file use unescaped backticks (`!``). This created visual inconsistency in the documentation.

## Solution

Removed the backslash escaping from the two affected lines to match the file's consistent pattern.

### Changes

- `plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md`: Remove `\` from `!\`` syntax on lines 396 and 398

## Testing

- [x] Verified no escaped backticks remain in file
- [x] Verified 27 unescaped bash execution patterns now consistent
- [x] Markdownlint passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)