### PR TITLE
fix(command-development): correct grep pattern in testing-strategies

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/testing-strategies.md
+++ b/plugins/plugin-dev/skills/command-development/references/testing-strategies.md
@@ -677,7 +677,7 @@ echo "Test: \$1 and \$2" > .claude/commands/test-args.md
 grep "allowed-tools" .claude/commands/my-command.md
 
 # Verify command syntax
-grep '!\`' .claude/commands/my-command.md
+grep '!`' .claude/commands/my-command.md
 
 # Test command manually
 date


### PR DESCRIPTION
## Summary

Fix incorrect grep pattern in troubleshooting documentation.

## Problem

The grep command for verifying bash command syntax was searching for `!\`` (escaped backtick) instead of `!`` (the actual bash pre-execution syntax).

## Solution

Changed `grep '!\`'` to `grep '!`'` to match the correct pattern.

## Testing

- [x] Markdownlint passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)