### PR TITLE
docs(command-development): improve discoverability and future-proof model IDs

### DIFF
--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: command-development
-description: This skill should be used when the user asks to "create a slash command", "add a command", "write a custom command", "define command arguments", "use command frontmatter", "organize commands", "create command with file references", "interactive command", "use AskUserQuestion in command", "SlashCommand tool", "programmatic command invocation", "disable-model-invocation", "prevent Claude from running command", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, programmatic invocation control, or command development best practices for Claude Code.
+description: This skill should be used when the user asks to "create a slash command", "add a command", "write a custom command", "define command arguments", "use command frontmatter", "organize commands", "create command with file references", "interactive command", "use AskUserQuestion in command", "SlashCommand tool", "programmatic command invocation", "disable-model-invocation", "prevent Claude from running command", "debug command", "command debugging", "troubleshoot command", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, programmatic invocation control, debugging commands, or command development best practices for Claude Code.
 ---
 
 # Command Development for Claude Code

--- a/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md
+++ b/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md
@@ -135,11 +135,11 @@ allowed-tools: "*"
 **Values:**
 
 - Shorthand: `sonnet`, `opus`, `haiku`
-- Full model ID: `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, etc.
+- Full model ID: Format is `claude-<family>-<version>-<date>` (e.g., `claude-sonnet-4-5-20250929`)
 
 Both formats are accepted. Shorthand names use the current default version of each model family.
 
-> **Note:** Model ID examples above reflect December 2025 releases. Anthropic releases new model versions periodically. For current model IDs, consult [Claude Models Overview](https://docs.anthropic.com/en/docs/about-claude/models).
+> **Note:** Anthropic releases new model versions periodically. For current model IDs, consult [Claude Models Overview](https://docs.anthropic.com/en/docs/about-claude/models). Prefer shorthand names unless you need a specific version.
 
 **Purpose:** Specify which Claude model executes the command
 
@@ -447,7 +447,7 @@ allowed-tools: Bash  # ❌ Missing command filter
 model: gpt4  # ❌ Not a valid Claude model
 ```
 
-**Fix:** Use shorthand (`sonnet`, `opus`, `haiku`) or full model ID (e.g., `claude-sonnet-4-5-20250929`)
+**Fix:** Use shorthand (`sonnet`, `opus`, `haiku`) or full model ID (see [Claude Models Overview](https://docs.anthropic.com/en/docs/about-claude/models))
 
 ### Validation Checklist
 


### PR DESCRIPTION
## Summary
- Add debug-related trigger phrases to skill description for better discoverability
- Update model ID examples to use generic placeholder format
- Add guidance to prefer shorthand names unless specific version needed

## Problem
Fixes #60

The `command-development` skill was missing trigger phrases for debugging scenarios despite `testing-strategies.md` covering them. Model ID examples used specific version dates that would become stale as new models release.

## Solution
Added "debug command", "command debugging", and "troubleshoot command" trigger phrases to SKILL.md description, along with "debugging commands" in the guidance topics.

Updated frontmatter-reference.md to:
- Use generic `claude-<family>-<version>-<date>` format with one concrete example
- Simplify the note to emphasize shorthand preference
- Add link to official docs in the validation section fix

### Alternatives Considered
- Could have removed all specific model ID examples entirely, but keeping one example helps users understand the format
- Could have updated to new docs.claude.com URL, but the redirect from docs.anthropic.com works fine

## Changes
- `SKILL.md`: Added debug trigger phrases to description
- `frontmatter-reference.md`: Updated model ID format documentation in 2 locations

## Testing
- [x] markdownlint passes
- [x] Verified Claude models documentation link works (via redirect)
- [x] No syntax errors in YAML frontmatter

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)