### PR TITLE
docs(hook-development): remove duplicated temporarily active hooks section

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -528,55 +528,6 @@ All matching hooks run **in parallel**:
 3. Cache validation results in temp files
 4. Minimize I/O in hot paths
 
-## Temporarily Active Hooks
-
-Create hooks that activate conditionally by checking for a flag file or configuration:
-
-### Pattern: Flag file activation
-
-```bash
-#!/bin/bash
-# Only active when flag file exists
-FLAG_FILE="$CLAUDE_PROJECT_DIR/.enable-strict-validation"
-
-if [ ! -f "$FLAG_FILE" ]; then
-  # Flag not present, skip validation
-  exit 0
-fi
-
-# Flag present, run validation
-input=$(cat)
-# ... validation logic ...
-```
-
-### Pattern: Configuration-based activation
-
-```bash
-#!/bin/bash
-# Check configuration for activation
-CONFIG_FILE="$CLAUDE_PROJECT_DIR/.claude/plugin-config.json"
-
-if [ -f "$CONFIG_FILE" ]; then
-  enabled=$(jq -r '.strictMode // false' "$CONFIG_FILE")
-  if [ "$enabled" != "true" ]; then
-    exit 0  # Not enabled, skip
-  fi
-fi
-
-# Enabled, run hook logic
-input=$(cat)
-# ... hook logic ...
-```
-
-**Use cases:**
-
-- Enable strict validation only when needed
-- Temporary debugging hooks
-- Project-specific hook behavior
-- Feature flags for hooks
-
-**Best practice:** Document activation mechanism in plugin README so users know how to enable/disable temporary hooks.
-
 ## Hook Lifecycle and Limitations
 
 ### Hooks Load at Session Start
@@ -681,7 +632,7 @@ echo "$output" | jq .
 
 For detailed patterns and advanced techniques, consult:
 
-- **`references/patterns.md`** - Common hook patterns (8+ proven patterns)
+- **`references/patterns.md`** - 10 proven patterns including temporarily active and configuration-driven hooks
 - **`references/migration.md`** - Migrating from basic to advanced hooks
 - **`references/advanced.md`** - Advanced use cases and techniques
 


### PR DESCRIPTION
## Summary
- Removed duplicated "Temporarily Active Hooks" section from SKILL.md (50 lines)
- Updated patterns.md reference to "10 proven patterns including temporarily active and configuration-driven hooks"
- Word count reduced from 2,125 → 1,979 words (now within 1,500-2,000 target)

## Problem
Fixes #65

The "Temporarily Active Hooks" section in SKILL.md duplicates content from `references/patterns.md` (Pattern 9: Temporarily Active Hooks and Pattern 10: Configuration-Driven Hooks), violating the skill-development best practice of keeping SKILL.md lean through progressive disclosure.

## Solution
Removed the duplicated section and enhanced the reference to patterns.md to explicitly mention the temporarily active and configuration-driven hook patterns.

### Alternatives Considered
- **Keep both with cross-reference**: Rejected because it still violates the single-source principle
- **Move patterns.md content to SKILL.md**: Rejected because patterns.md has more comprehensive examples

## Changes
- `plugins/plugin-dev/skills/hook-development/SKILL.md`: Removed lines 531-578, updated patterns.md reference

## Testing
- [x] Markdownlint passes
- [x] Word count verified (2,125 → 1,979)
- [x] Content verified in patterns.md (Pattern 9 & 10)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)