### PR TITLE
docs(hook-development): add PermissionRequest hook event documentation

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -38,7 +38,7 @@ echo "✅ Valid JSON"
 # Check 2: Root structure
 echo ""
 echo "Checking root structure..."
-VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
+VALID_EVENTS=("PreToolUse" "PermissionRequest" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
 
 for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
   found=false


### PR DESCRIPTION
## Summary
- Added documentation for the PermissionRequest hook event
- Updated validate-hook-schema.sh to recognize PermissionRequest as a valid event
- PermissionRequest allows automatic allow/deny of permission dialogs

## Problem
Fixes #67

The hook-development skill was missing documentation for PermissionRequest, which is a valid hook event in the official Claude Code documentation. This caused:
1. Users not knowing about this capability
2. The validation script incorrectly warning about PermissionRequest being unknown

## Solution
Added comprehensive documentation for PermissionRequest:
- New section in Hook Events with example configuration and output format
- Added to skill description trigger list
- Added to Quick Reference table
- Added to event-specific input fields
- Added to VALID_EVENTS in validate-hook-schema.sh

### Alternatives Considered
- **Document as "not supported for plugins"**: Rejected because official docs show it's available
- **Minimal one-line addition**: Rejected because consistent documentation requires the same treatment as other events

## Changes
- `plugins/plugin-dev/skills/hook-development/SKILL.md`: Added PermissionRequest documentation (+50 lines)
- `plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh`: Added PermissionRequest to VALID_EVENTS

## Testing
- [x] Markdownlint passes
- [x] Shellcheck shows only pre-existing warnings (not related to this change)
- [x] Documentation follows existing patterns

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)