### PR TITLE
docs(mcp-integration): add WebSocket server example

### DIFF
--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -528,6 +528,7 @@ Working examples in `examples/`:
 - **`stdio-server.json`** - Local stdio MCP server
 - **`sse-server.json`** - Hosted SSE server with OAuth
 - **`http-server.json`** - REST API with token auth
+- **`ws-server.json`** - WebSocket server for real-time communication
 
 ### External Resources
 

--- a/plugins/plugin-dev/skills/mcp-integration/examples/ws-server.json
+++ b/plugins/plugin-dev/skills/mcp-integration/examples/ws-server.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Example WebSocket MCP server configuration for real-time bidirectional communication",
+  "realtime-service": {
+    "type": "ws",
+    "url": "wss://mcp.example.com/ws",
+    "headers": {
+      "Authorization": "Bearer ${TOKEN}"
+    }
+  },
+  "streaming-data": {
+    "type": "ws",
+    "url": "wss://stream.example.com/mcp",
+    "headers": {
+      "X-API-Key": "${API_KEY}",
+      "X-Client-ID": "${CLIENT_ID}"
+    }
+  },
+  "live-updates": {
+    "type": "ws",
+    "url": "wss://live.example.com/mcp/v1",
+    "headers": {
+      "Authorization": "Bearer ${WS_TOKEN}",
+      "X-Connection-Type": "persistent"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add missing `ws-server.json` example file to the mcp-integration skill's examples directory, completing coverage of all 4 MCP server types documented in SKILL.md.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

The mcp-integration skill documents 4 MCP server types (stdio, SSE, HTTP, WebSocket) in SKILL.md, but the `examples/` directory only contained 3 example files. This creates a completeness gap where users looking for a WebSocket example must extract it from the SKILL.md body rather than having a dedicated, well-commented example file.

Fixes #70

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: 1.0.32
- GitHub CLI version: 2.74.1
- OS: macOS

**Test Steps**:
1. Verified new JSON file is valid JSON
2. Ran `markdownlint` on SKILL.md - no errors
3. Confirmed example follows same pattern as existing examples

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

## Additional Notes

The new `ws-server.json` includes three example configurations to match the depth of existing examples:
- `realtime-service` - Basic WebSocket with Bearer token auth
- `streaming-data` - WebSocket with API key and client ID headers
- `live-updates` - WebSocket with custom connection headers

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)