### PR TITLE
docs: fix second-person usage in mcp-integration skill

### DIFF
--- a/plugins/plugin-dev/skills/mcp-integration/references/tool-usage.md
+++ b/plugins/plugin-dev/skills/mcp-integration/references/tool-usage.md
@@ -406,7 +406,7 @@ This command uses the following Asana MCP tools:
 - **asana_create_task**: Create new task with details
 - **asana_update_task**: Update existing task properties
 
-Ensure you're authenticated to Asana before running this command.
+Ensure authentication to Asana before running this command.
 ```
 
 ## Testing Tool Usage


### PR DESCRIPTION
## Summary

Fix second-person pronoun usage ("you're") in the mcp-integration skill reference file to follow skill writing style guidelines requiring imperative form.

## Problem

Fixes #79

The skill reference file used second-person ("Ensure you're authenticated") in instructional text at line 409, violating the skill development guidelines which require imperative/infinitive form.

## Solution

Changed "Ensure you're authenticated to Asana before running this command." to "Ensure authentication to Asana before running this command." using Option 1 from the issue.

### Alternatives Considered

- **Option 2 (passive)**: "Authentication to Asana is required before running this command." - More natural but less consistent with imperative style used elsewhere.

## Changes

- `plugins/plugin-dev/skills/mcp-integration/references/tool-usage.md`: Line 409 updated to imperative form

## Testing

- [x] Markdownlint passes
- [x] Change follows skill writing style guidelines

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)