### PR TITLE
docs(plugin-settings): fix allowed-tools syntax to use comma-separated format

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -102,7 +102,7 @@ Commands can read settings files to customize behavior:
 ```markdown
 ---
 description: Process data with plugin
-allowed-tools: ["Read", "Bash"]
+allowed-tools: Read, Bash
 ---
 
 # Process Command

--- a/plugins/plugin-dev/skills/plugin-settings/examples/create-settings-command.md
+++ b/plugins/plugin-dev/skills/plugin-settings/examples/create-settings-command.md
@@ -1,6 +1,6 @@
 ---
 description: "Create plugin settings file with user preferences"
-allowed-tools: ["Write", "AskUserQuestion"]
+allowed-tools: Write, AskUserQuestion
 ---
 
 # Create Plugin Settings


### PR DESCRIPTION
## Summary

Fix `allowed-tools` frontmatter syntax in the plugin-settings skill to use the official comma-separated string format instead of JSON array syntax.

## Problem

Fixes #82

The `allowed-tools` field in two files used incorrect JSON array syntax `["Tool1", "Tool2"]` instead of the official comma-separated format `Tool1, Tool2` per Claude Code documentation.

## Solution

Changed the syntax in both files to match official documentation:

| File | Before | After |
|------|--------|-------|
| `SKILL.md:105` | `allowed-tools: ["Read", "Bash"]` | `allowed-tools: Read, Bash` |
| `examples/create-settings-command.md:3` | `allowed-tools: ["Write", "AskUserQuestion"]` | `allowed-tools: Write, AskUserQuestion` |

### Alternatives Considered

None - the fix is unambiguous and directly specified by official Claude Code documentation.

## Changes

- `plugins/plugin-dev/skills/plugin-settings/SKILL.md`: Fixed `allowed-tools` syntax on line 105
- `plugins/plugin-dev/skills/plugin-settings/examples/create-settings-command.md`: Fixed `allowed-tools` syntax on line 3

## Testing

- [x] Linting passes (markdownlint)
- [x] No code changes requiring tests

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)