### PR TITLE
docs: add missing PermissionRequest hook event

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use this workflow for structured, high-quality plugin development from concept t
 **What it covers:**
 - Prompt-based hooks (recommended) with LLM decision-making
 - Command hooks for deterministic validation
-- All hook events: PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
+- All hook events: PreToolUse, PermissionRequest, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
 - Hook output formats and JSON schemas
 - Security best practices and input validation
 - ${CLAUDE_PLUGIN_ROOT} for portable paths

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -235,7 +235,7 @@ hooks/
 }
 ```
 
-**Available events**: PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
+**Available events**: PreToolUse, PermissionRequest, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
 
 **Usage**: Hooks execute automatically in response to Claude Code events
 


### PR DESCRIPTION
## Summary
Add the missing `PermissionRequest` event to hook events documentation in two locations where it was omitted.

## Problem
Fixes #85

The `PermissionRequest` hook event was missing from the hook events list in:
- `plugins/plugin-dev/skills/plugin-structure/SKILL.md:238`
- `README.md:63`

This event fires when a permission dialog is shown and is documented in the official Claude Code reference but was absent from this plugin's documentation.

## Solution
Added `PermissionRequest` to both hook events lists, placing it between `PreToolUse` and `PostToolUse` to match the official documentation order.

### Alternatives Considered
None - this is a straightforward documentation fix to align with official docs.

## Changes
- `plugins/plugin-dev/skills/plugin-structure/SKILL.md`: Added PermissionRequest to available events
- `README.md`: Added PermissionRequest to hook events list

## Testing
- [x] markdownlint passes
- [x] Verified order matches official Claude Code documentation

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)