### PR TITLE
docs(plugin-structure): fix hooks.json format with required wrapper

### DIFF
--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -224,14 +224,16 @@ hooks/
 
 ```json
 {
-  "PreToolUse": [{
-    "matcher": "Write|Edit",
-    "hooks": [{
-      "type": "command",
-      "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate.sh",
-      "timeout": 30
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Write|Edit",
+      "hooks": [{
+        "type": "command",
+        "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate.sh",
+        "timeout": 30
+      }]
     }]
-  }]
+  }
 }
 ```
 

--- a/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
@@ -629,69 +629,71 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh de
 
 ```json
 {
-  "PreToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/scan-secrets.sh",
-          "timeout": 30
-        }
-      ]
-    },
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "Evaluate if this bash command is safe for production environment. Check for destructive operations, missing safeguards, and potential security issues. Commands should be idempotent and reversible.",
-          "timeout": 20
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/update-status.sh",
-          "timeout": 15
-        }
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/quality/check-config.sh",
-          "timeout": 45
-        },
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/notify-team.sh",
-          "timeout": 30
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/validate-permissions.sh",
-          "timeout": 20
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/scan-secrets.sh",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Evaluate if this bash command is safe for production environment. Check for destructive operations, missing safeguards, and potential security issues. Commands should be idempotent and reversible.",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/update-status.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/quality/check-config.sh",
+            "timeout": 45
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/notify-team.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/validate-permissions.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md
@@ -426,30 +426,32 @@ See language-specific guides for:
 
 ```json
 {
-  "PreToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "Before modifying code, verify it meets our coding standards from the code-standards skill. Check formatting, naming conventions, and documentation. If standards aren't met, suggest improvements.",
-          "timeout": 30
-        }
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-commit.sh",
-          "timeout": 45
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Before modifying code, verify it meets our coding standards from the code-standards skill. Check formatting, naming conventions, and documentation. If standards aren't met, suggest improvements.",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-commit.sh",
+            "timeout": 45
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
@@ -306,10 +306,12 @@ hooks/
 **hooks.json**:
 ```json
 {
-  "PreToolUse": [...],
-  "PostToolUse": [...],
-  "Stop": [...],
-  "SessionStart": [...]
+  "hooks": {
+    "PreToolUse": [...],
+    "PostToolUse": [...],
+    "Stop": [...],
+    "SessionStart": [...]
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes incorrect hooks.json examples in the plugin-structure skill that were missing the required `"hooks"` wrapper object.

## Problem

Fixes #90

All hooks.json examples in the plugin-structure skill showed an incorrect format that would cause plugins created from these examples to have broken hooks. The examples were missing the required `"hooks"` wrapper:

**Before (incorrect):**
```json
{
  "PreToolUse": [...]
}
```

**After (correct):**
```json
{
  "hooks": {
    "PreToolUse": [...]
  }
}
```

## Solution

Updated all 4 affected files to use the correct wrapper format, consistent with the hook-development skill and official documentation:

- `plugins/plugin-dev/skills/plugin-structure/SKILL.md`
- `plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md`
- `plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md`
- `plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md`

### Alternatives Considered

None - this is a documentation correctness fix with a single correct answer.

## Changes

- Added `"hooks"` wrapper object to all hooks.json code examples
- No functional changes, documentation only

## Testing

- [x] All tests passing (N/A - documentation only)
- [x] Linting passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)