### PR TITLE
docs: fix second-person writing style in marketplace-structure skill

### DIFF
--- a/plugins/plugin-dev/skills/marketplace-structure/references/distribution-patterns.md
+++ b/plugins/plugin-dev/skills/marketplace-structure/references/distribution-patterns.md
@@ -296,7 +296,7 @@ Before adding external plugins to your marketplace:
 
 1. Verify plugin source URL is accessible
 2. Check plugin directory contains required files
-3. For GitHub sources, ensure repository is public or you have access
+3. For GitHub sources, ensure repository is public or access is available
 4. Test plugin sources manually by cloning
 
 ### Validation Commands


### PR DESCRIPTION
## Summary

Single-word fix to maintain imperative writing style in the marketplace-structure skill's distribution-patterns reference document.

## Problem

Fixes #94

The skill-development best practices require imperative/infinitive form, not second person. Line 299 of `distribution-patterns.md` contained "you have access" which violated this guideline.

## Solution

Changed "ensure repository is public or you have access" to "ensure repository is public or access is available".

This maintains the imperative verb ("ensure") while removing the second-person pronoun, consistent with the writing style used throughout the rest of the skill.

### Alternatives Considered

- "ensure repository is public or appropriate access exists" - More verbose, unnecessary
- "ensure repository accessibility" - Loses clarity about public vs private repos

The chosen fix is minimal and maintains the original sentence structure.

## Changes

- `plugins/plugin-dev/skills/marketplace-structure/references/distribution-patterns.md`: Line 299 - "you have access" → "access is available"

## Testing

- [x] markdownlint passes
- [x] No other files affected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)