### PR TITLE
docs: add ${CLAUDE_PLUGIN_ROOT} explanation to marketplace-structure skill

### DIFF
--- a/plugins/plugin-dev/skills/marketplace-structure/references/schema-reference.md
+++ b/plugins/plugin-dev/skills/marketplace-structure/references/schema-reference.md
@@ -150,6 +150,8 @@ For GitLab, Bitbucket, or self-hosted git repositories:
 
 ## Complete Plugin Entry Example
 
+**Note:** The `${CLAUDE_PLUGIN_ROOT}` variable in the example below resolves to the plugin's absolute installation path. Use this variable for portable paths in hooks and MCP server configurations, ensuring paths work regardless of where the plugin is installed.
+
 Advanced plugin entry with all optional fields:
 
 ```json


### PR DESCRIPTION
## Summary

Add explanatory note for the `${CLAUDE_PLUGIN_ROOT}` environment variable in the marketplace-structure skill's schema reference documentation.

## Problem

Fixes #95

The `${CLAUDE_PLUGIN_ROOT}` environment variable is used in the hooks and mcpServers examples within the Complete Plugin Entry Example, but wasn't explicitly explained. Users unfamiliar with plugin development may not understand what this variable represents.

## Solution

Added a brief note directly before the Complete Plugin Entry Example that explains:
- What `${CLAUDE_PLUGIN_ROOT}` resolves to (plugin's absolute installation path)
- When to use it (hooks and MCP server configurations)
- Why it matters (portable paths regardless of installation location)

This approach was chosen over adding a new subsection because:
1. It's contextual - explains the variable right where it's used
2. Simpler and less intrusive to the document structure
3. Provides just-in-time information for users reading the example

### Alternatives Considered

- **New "### Environment Variables" subsection** after Component Configuration Fields - More prominent but disrupts document flow and may be overkill for a single variable note
- **Inline code comment** in the JSON example - Would require multiple comments and break JSON syntax highlighting

## Changes

- `plugins/plugin-dev/skills/marketplace-structure/references/schema-reference.md`: Added note before Complete Plugin Entry Example explaining `${CLAUDE_PLUGIN_ROOT}`

## Testing

- [x] markdownlint passes
- [x] No other files affected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)