### PR TITLE
fix: correct phase count and add Edit tool to create-plugin command

### DIFF
--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -1,7 +1,7 @@
 ---
 description: Guided end-to-end plugin creation workflow with component design, implementation, and validation
 argument-hint: Optional plugin description
-allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
+allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
 ---
 
 # Plugin Creation Workflow
@@ -26,7 +26,7 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
 **Goal**: Understand what plugin needs to be built and what problem it solves
 
 **Actions**:
-1. Create todo list with all 7 phases
+1. Create todo list with all 8 phases
 2. If plugin purpose is clear from arguments:
    - Summarize understanding
    - Identify plugin type (integration, workflow, analysis, toolkit, etc.)


### PR DESCRIPTION
## Summary

Fixes two bugs in the `/plugin-dev:create-plugin` command:
- Corrected phase count reference from "7 phases" to "8 phases" on line 29
- Added `Edit` tool to `allowed-tools` frontmatter for marketplace.json updates in Phase 8

## Problem

Fixes #98

The create-plugin command had inconsistencies:
1. Line 29 instructed Claude to "Create todo list with all 7 phases" but the command defines 8 phases (Discovery through Documentation)
2. Phase 8 allows updating `marketplace.json` but the `Edit` tool was missing from `allowed-tools`, preventing file modification

## Solution

- Changed "7 phases" to "8 phases" on line 29
- Added `Edit` to the `allowed-tools` array in frontmatter

### Alternatives Considered

None - this is a straightforward bug fix with clear expected behavior.

## Changes

- `plugins/plugin-dev/commands/create-plugin.md`: Fixed phase count and added Edit tool

## Testing

- [x] Linting passes
- [x] Changes verified via git diff

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)