### PR TITLE
fix: make Bash tool validation rule contextual for workflow commands

### DIFF
--- a/.github/workflows/component-validation.yml
+++ b/.github/workflows/component-validation.yml
@@ -96,7 +96,8 @@ jobs:
             - [ ] YAML frontmatter exists with `name`, `description`, `allowed-tools` fields
             - [ ] `description` is 60 characters or fewer
             - [ ] `allowed-tools` follows these rules:
-              - MUST use `Bash(gh:*)` not unrestricted `Bash` (security requirement)
+              - For simple commands needing only specific CLI operations: prefer Bash prefix patterns like `Bash(gh pr:*)`, `Bash(npm run:*)` (uses prefix matching with `:*` wildcard)
+              - Unrestricted `Bash` is acceptable for workflow/scaffolding commands that legitimately need filesystem operations (mkdir, git init, directory creation) - verify the command's stated purpose justifies broader access
               - `Read` is always allowed (reading files is safe)
               - `Write` is allowed ONLY if the command creates/exports files (e.g., status export)
               - `AskUserQuestion` is always allowed (user interaction is safe)


### PR DESCRIPTION
## Summary

Updates the component validation workflow to use a contextual Bash tool rule instead of a blanket restriction, and corrects the Bash pattern syntax to match official documentation.

## Problem

The validation rule at line 99 was:
```
- MUST use `Bash(gh:*)` not unrestricted `Bash` (security requirement)
```

This caused PR #100 to fail validation because `create-plugin.md` uses unrestricted `Bash` - but it **legitimately needs** broader access for:
- `mkdir -p` - creating plugin directory structures
- `git init` - initializing git repositories
- Other filesystem operations

Additionally, the syntax `Bash(gh:*)` doesn't match official documentation, which specifies prefix matching with `:*` (e.g., `Bash(gh pr:*)`).

## Solution

Updated the validation rule to be contextual:

1. **For simple commands**: Recommend Bash prefix patterns like `Bash(gh pr:*)`, `Bash(npm run:*)`
2. **For workflow/scaffolding commands**: Allow unrestricted `Bash` when the command's purpose justifies filesystem operations
3. **Fixed syntax**: Use correct `:*` wildcard notation per [official docs](https://docs.anthropic.com/en/docs/claude-code/settings#tool-specific-permission-rules)

### Alternatives Considered

| Option | Why Not Chosen |
|--------|----------------|
| Keep blanket restriction | Breaks legitimate workflow commands |
| Allowlist specific commands | Doesn't scale, maintenance burden |
| Remove rule entirely | Loses security guidance for simple commands |

## Changes

- `.github/workflows/component-validation.yml`: Updated Bash validation rule (lines 99-100)

## Testing

- [x] actionlint passes
- [x] Syntax matches official Claude Code documentation

## Related

- Unblocks PR #100 (fix: correct phase count and add Edit tool to create-plugin command)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)