### PR TITLE
docs: update create-plugin command frontmatter to follow best practices

### DIFF
--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -1,7 +1,7 @@
 ---
-description: Guided end-to-end plugin creation workflow with component design, implementation, and validation
-argument-hint: Optional plugin description
-allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
+description: Create plugins with guided 8-phase workflow
+argument-hint: "[plugin-description]"
+allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash(mkdir:*)", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
 ---
 
 # Plugin Creation Workflow


### PR DESCRIPTION
## Summary

Updates the `create-plugin.md` command frontmatter to align with Claude Code slash command best practices documented in official docs and the `command-development` skill.

## Problem

Fixes #99

The command's YAML frontmatter had three style issues:
1. **Description too long** (96 chars, recommended < 60)
2. **argument-hint missing bracket convention** (should use `[]`)
3. **Unrestricted Bash tool** (command only uses `mkdir`)

## Solution

Updated frontmatter with these changes:
- Shortened description from 96 to 43 characters: `Create plugins with guided 8-phase workflow`
- Added bracket convention to argument-hint: `[plugin-description]`
- Restricted Bash to `Bash(mkdir:*)` since the command only uses `mkdir` commands

### Alternatives Considered

- Keeping unrestricted Bash for flexibility - rejected because best practices say "be as restrictive as possible" and the command content only uses `mkdir`

## Changes

- `plugins/plugin-dev/commands/create-plugin.md`: Updated YAML frontmatter (lines 2-4)

## Testing

- [x] Command validators pass (`validate-command.sh`, `check-frontmatter.sh`)
- [x] Markdownlint passes
- [x] Description now 43 chars (under 60 limit)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)