### PR TITLE
fix: expand create-plugin allowed-tools and clarify validation approach

### DIFF
--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -1,7 +1,7 @@
 ---
 description: Create plugins with guided 8-phase workflow
 argument-hint: "[plugin-description]"
-allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash(mkdir:*)", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
 ---
 
 # Plugin Creation Workflow
@@ -199,7 +199,7 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
    - Agent-creator generates: identifier, whenToUse with examples, systemPrompt
    - Create agent markdown file with frontmatter and system prompt
    - Add appropriate model, color, and tools
-   - Validate with validate-agent.sh script
+   - Validate using plugin-validator agent
 
 ### For Hooks
 
@@ -209,7 +209,7 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
    - Prefer prompt-based hooks for complex logic
    - Use ${CLAUDE_PLUGIN_ROOT} for portability
    - Create hook scripts if needed (in examples/ not scripts/)
-   - Test with validate-hook-schema.sh and test-hook.sh utilities
+   - Validate using plugin-validator agent (handles hook schema validation)
 
 ### For MCP
 
@@ -258,11 +258,10 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
 4. **Test agent triggering** (if plugin has agents):
    - For each agent, verify <example> blocks are clear
    - Check triggering conditions are specific
-   - Run validate-agent.sh on agent files
+   - Verify via plugin-validator agent
 
 5. **Test hook configuration** (if plugin has hooks):
-   - Run validate-hook-schema.sh on hooks/hooks.json
-   - Test hook scripts with test-hook.sh
+   - Validate via plugin-validator agent (checks hook schema and scripts)
    - Verify ${CLAUDE_PLUGIN_ROOT} usage
 
 6. **Present findings**:


### PR DESCRIPTION
## Summary

Fixes the `create-plugin` command's tool restrictions that prevented git initialization and clarifies that validation runs through agents rather than direct script execution.

## Problem

Fixes #103

The command's `allowed-tools` only permitted `Bash(mkdir:*)`, but the instructions told Claude to:
1. Run `git init` (Phase 4, line 147)
2. Execute validation scripts directly (Phases 5-6)

This created a mismatch between what the command instructed and what tools were available.

## Solution

**Approach taken:** Minimal Bash expansion + clarify agent-based validation

1. **Added `Bash(git init:*)`** - Enables git initialization as instructed in Phase 4
2. **Converted to comma-separated format** - Matches official documentation style
3. **Updated validation references** - Clarified that the `plugin-validator` agent handles validation (it has full Bash access and uses the scripts internally)

### Alternatives Considered

1. **Add `Bash(bash:*)`** - Rejected as too permissive; would allow arbitrary script execution
2. **Remove all script references** - Rejected as it loses useful context about what agents do
3. **Add specific script patterns** - Rejected as overly complex; agents already have proper permissions

## Changes

- `plugins/plugin-dev/commands/create-plugin.md`:
  - Line 4: Added `Bash(git init:*)`, converted to comma-separated format
  - Line 202: Changed "Validate with validate-agent.sh script" → "Validate using plugin-validator agent"
  - Line 212: Changed direct script reference → agent-based validation
  - Lines 261, 264-265: Updated Phase 6 validation to reference agents

## Testing

- [x] Linting passes (`markdownlint`)
- [x] Verified plugin-validator agent has Bash access and references scripts internally
- [x] Changes follow principle of least privilege

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)