### PR TITLE
fix: restrict Bash tool access in create-marketplace command

### DIFF
--- a/plugins/plugin-dev/commands/create-marketplace.md
+++ b/plugins/plugin-dev/commands/create-marketplace.md
@@ -1,7 +1,7 @@
 ---
 description: Create plugin marketplaces with guided workflow
 argument-hint: [marketplace-description]
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, AskUserQuestion, Skill, Task
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), TodoWrite, AskUserQuestion, Skill, Task
 ---
 
 # Marketplace Creation Workflow


### PR DESCRIPTION
## Summary

Restrict Bash tool access from unrestricted `Bash` to `Bash(mkdir:*)` in the create-marketplace command, following the least-privilege security principle.

## Problem

Fixes #106

The `create-marketplace` command had unrestricted `Bash` in its allowed-tools, violating:
- The command-development skill best practice (SKILL.md:469): "Limit scope: Use `Bash(git:*)` not `Bash(*)`"
- Consistency with the sister command `create-plugin.md` which properly restricts Bash access

## Solution

Changed `Bash` to `Bash(mkdir:*)` since the command only needs `mkdir -p` for directory creation (lines 131-136 in the command body).

### Alternatives Considered

1. **Keep unrestricted** - Rejected; violates least-privilege principle
2. **Add more patterns like `Bash(mkdir:*), Bash(git init:*)`** - Rejected; create-marketplace doesn't need git init (unlike create-plugin)

## Changes

- `plugins/plugin-dev/commands/create-marketplace.md`: Change `Bash` → `Bash(mkdir:*)`

## Testing

- [x] Markdownlint passes
- [x] Change follows established pattern from create-plugin.md

## Security Note

This is a defense-in-depth improvement. While Claude exercises judgment regardless, restricting permissions:
- Documents the intended scope
- Provides an additional safety layer
- Maintains consistency across commands

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)