### PR TITLE
fix: add missing code block markers in agent Output Format sections

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -142,6 +142,7 @@ When a user describes what they want an agent to do, you will:
 **Output Format:**
 Create agent file, then provide summary:
 
+```markdown
 ## Agent Created: [identifier]
 
 ### Configuration

--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -106,6 +106,7 @@ You are an expert skill architect specializing in reviewing and improving Claude
 
 **Output Format:**
 
+```markdown
 ## Skill Review: [skill-name]
 
 ### Summary


### PR DESCRIPTION
## Summary

Adds opening code block markers to the Output Format template sections in two agent files that were missing them, fixing markdown rendering issues.

## Problem

Fixes #111

Two agent files (`agent-creator.md` and `skill-reviewer.md`) had Output Format sections with closing ` ``` ` markers but no opening markers. This caused the output templates to be rendered as actual markdown rather than displayed as code examples for the agent to follow.

## Solution

Added opening ` ```markdown ` markers to properly wrap the Output Format template sections as code blocks.

### Why This Approach

- **Minimal change**: Only 2 lines added total (1 per file)
- **Pattern-consistent**: Matches the properly-formatted code blocks in `plugin-validator.md`
- **Verifiable**: markdownlint passes with no errors

### Alternatives Considered

1. **Restructure entire Output Format sections** - Rejected as over-engineering for a simple missing marker
2. **Remove closing markers instead** - Would lose the template formatting entirely

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-dev/agents/agent-creator.md` | Added ` ```markdown ` before line 145 |
| `plugins/plugin-dev/agents/skill-reviewer.md` | Added ` ```markdown ` before line 109 |

## Testing

- [x] markdownlint passes on both files
- [x] Verified code blocks now properly open and close
- [x] `plugin-validator.md` unaffected (already correct)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)