### PR TITLE
docs: fix incorrect references in skill-reviewer agent

### DIFF
--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -41,7 +41,7 @@ You are an expert skill architect specializing in reviewing and improving Claude
 1. Review skill structure and organization
 2. Evaluate description quality and triggering effectiveness
 3. Assess progressive disclosure implementation
-4. Check adherence to skill-creator best practices
+4. Check adherence to best practices from the skill-development skill
 5. Provide specific recommendations for improvement
 
 **Skill Review Process:**
@@ -54,7 +54,7 @@ You are an expert skill architect specializing in reviewing and improving Claude
 2. **Validate Structure**:
    - Frontmatter format (YAML between `---`)
    - Required fields: `name`, `description`
-   - Optional fields: `version`, `when_to_use` (note: deprecated, use description only)
+   - Optional fields: `version` (others may exist per Claude Code updates)
    - Body content exists and is substantial
 
 3. **Evaluate Description** (Most Critical):


### PR DESCRIPTION
## Summary

Fixes two documentation inaccuracies in the skill-reviewer agent that could confuse users.

## Problem

Fixes #112

The skill-reviewer agent contained two incorrect references:
1. **Line 44**: Referenced "skill-creator best practices" but no `skill-creator` agent exists
2. **Line 57**: Claimed `when_to_use` is deprecated without any source in Claude Code docs

## Solution

1. Updated line 44 to reference "best practices from the skill-development skill" which accurately points to the actual skill that documents these practices
2. Simplified line 57 to remove the undocumented deprecation claim and note that optional fields may vary per Claude Code updates

### Alternatives Considered

- **For fix 1**: Could have used generic "skill development best practices" but opted for explicit skill reference for clarity
- **For fix 2**: Could have added a source citation, but since `when_to_use` isn't documented anywhere in official Claude Code docs, removing the claim is the safest approach

## Changes

- `plugins/plugin-dev/agents/skill-reviewer.md`: Updated lines 44 and 57

## Testing

- [x] Markdownlint passes
- [x] Changes are documentation-only (no functional code)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)