### PR TITLE
feat: improve agent consistency and documentation

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -29,9 +29,10 @@ Plugin development with agent addition, trigger agent-creator.
 </commentary>
 </example>
 
+# Explicit sonnet for complex agent generation reasoning
 model: sonnet
 color: magenta
-tools: ["Write", "Read"]
+tools: Write, Read
 ---
 
 You are an elite AI agent architect specializing in crafting high-performance agent configurations. Your expertise lies in translating user requirements into precisely-tuned agent specifications that maximize effectiveness and reliability.
@@ -116,7 +117,7 @@ When a user describes what they want an agent to do, you will:
    description: [Use this agent when... Examples: <example>...</example>]
    model: inherit
    color: [chosen-color]
-   tools: ["Tool1", "Tool2"]  # Optional
+   tools: Tool1, Tool2  # Optional
    ---
 
    [Complete system prompt]

--- a/plugins/plugin-dev/agents/plugin-validator.md
+++ b/plugins/plugin-dev/agents/plugin-validator.md
@@ -43,7 +43,7 @@ assistant: "I'll use the plugin-validator agent to check the marketplace."
 
 model: inherit
 color: yellow
-tools: ["Read", "Grep", "Glob", "Bash"]
+tools: Read, Grep, Glob, Bash
 ---
 
 You are an expert plugin and marketplace validator specializing in comprehensive validation of Claude Code plugin structure, configuration, components, and plugin marketplaces.
@@ -106,7 +106,7 @@ First, determine what type of validation is needed:
 5. **Validate Agents** (if `agents/` exists):
    - Use Glob to find `agents/**/*.md`
    - For each agent file:
-     - Use the validate-agent.sh utility from agent-development skill
+     - Use `./skills/agent-development/scripts/validate-agent.sh` utility
      - Or manually check:
        - Frontmatter with `name`, `description`, `model`, `color`
        - Name format (lowercase, hyphens, 3-50 chars)
@@ -125,7 +125,7 @@ First, determine what type of validation is needed:
      - Validate referenced files exist
 
 7. **Validate Hooks** (if `hooks/hooks.json` exists):
-   - Use the validate-hook-schema.sh utility from hook-development skill
+   - Use `./skills/hook-development/scripts/validate-hook-schema.sh` utility
    - Or manually check:
      - Valid JSON syntax
      - Valid event names (PreToolUse, PostToolUse, Stop, etc.)

--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -32,7 +32,7 @@ Skill description modified, review for triggering effectiveness.
 
 model: inherit
 color: cyan
-tools: ["Read", "Grep", "Glob"]
+tools: Read, Grep, Glob
 ---
 
 You are an expert skill architect specializing in reviewing and improving Claude Code skills for maximum effectiveness and reliability.


### PR DESCRIPTION
## Summary

- Aligns `tools` field format with official Claude Code documentation (comma-separated instead of JSON array)
- Adds explicit script paths in plugin-validator.md for immediate actionability
- Documents model choice rationale in agent-creator.md

## Problem

Fixes #113

## Solution

Applied all three improvements identified in the issue:

1. **tools format**: Changed from `["Tool1", "Tool2"]` to `Tool1, Tool2` in all 3 agents to match official docs
2. **script paths**: Changed vague references like "Use the validate-agent.sh utility from agent-development skill" to explicit paths like `./skills/agent-development/scripts/validate-agent.sh`
3. **model rationale**: Added YAML comment explaining why agent-creator uses explicit `sonnet` instead of `inherit`

### Alternatives Considered

- Inline comment for model rationale: Rejected because the validation script parsed it as part of the model value

## Changes

- `plugins/plugin-dev/agents/agent-creator.md`: tools format, model comment, example update
- `plugins/plugin-dev/agents/skill-reviewer.md`: tools format
- `plugins/plugin-dev/agents/plugin-validator.md`: tools format, explicit script paths

## Testing

- [x] All files pass markdownlint
- [x] All 3 agents pass validate-agent.sh validation
- [x] Changes verified via git diff

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)