### PR TITLE
feat: add skills field to agents for auto-loading relevant skills

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -33,6 +33,7 @@ Plugin development with agent addition, trigger agent-creator.
 model: sonnet
 color: magenta
 tools: Write, Read
+skills: agent-development
 ---
 
 You are an elite AI agent architect specializing in crafting high-performance agent configurations. Your expertise lies in translating user requirements into precisely-tuned agent specifications that maximize effectiveness and reliability.

--- a/plugins/plugin-dev/agents/plugin-validator.md
+++ b/plugins/plugin-dev/agents/plugin-validator.md
@@ -41,6 +41,7 @@ Marketplace created, validate schema and plugin entries.
 model: inherit
 color: yellow
 tools: Read, Grep, Glob, Bash
+skills: plugin-structure, hook-development, command-development, skill-development, agent-development
 ---
 
 You are an expert plugin and marketplace validator specializing in comprehensive validation of Claude Code plugin structure, configuration, components, and plugin marketplaces.

--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -32,6 +32,7 @@ Skill description modified, review for triggering effectiveness.
 model: inherit
 color: cyan
 tools: Read, Grep, Glob
+skills: skill-development
 ---
 
 You are an expert skill architect specializing in reviewing and improving Claude Code skills for maximum effectiveness and reliability.


### PR DESCRIPTION
## Summary

- Adds the `skills` frontmatter field to all 3 agents to auto-load relevant skill documentation when invoked
- Makes agents more self-contained and effective by providing them with domain-specific best practices

## Problem

Fixes #118

The plugin's agents don't leverage the `skills` frontmatter field to auto-load relevant context. Users need to manually load skills first, or agents operate without that documentation context.

## Solution

Add `skills` field to each agent's frontmatter:

| Agent | Skills Auto-loaded |
|-------|-------------------|
| `agent-creator` | agent-development |
| `plugin-validator` | plugin-structure, hook-development, command-development, skill-development, agent-development |
| `skill-reviewer` | skill-development |

### Alternatives Considered

1. **Status quo**: Users manually load skills (current behavior)
2. **Document in prompts**: Add references in system prompt text (doesn't auto-load)
3. **Single skill per agent**: Only load most relevant skill (less comprehensive for plugin-validator)

Chose the approach from the issue which provides comprehensive coverage while being targeted to each agent's needs.

## Changes

- `agent-creator.md`: Added `skills: agent-development`
- `plugin-validator.md`: Added `skills: plugin-structure, hook-development, command-development, skill-development, agent-development`
- `skill-reviewer.md`: Added `skills: skill-development`

## Testing

- [x] All modified files pass markdownlint
- [x] Skills referenced exist in the plugin

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)