### PR TITLE
feat: add proactive triggering example to agent-creator agent

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -29,6 +29,15 @@ Plugin development with agent addition, trigger agent-creator.
 </commentary>
 </example>
 
+<example>
+Context: User describes needing autonomous functionality while discussing plugin development
+user: "My plugin needs something to automatically review code after I write it"
+assistant: "I'll use the agent-creator agent to generate a code review agent for your plugin."
+<commentary>
+User describes agent-like functionality need without explicitly requesting agent creation, proactively trigger agent-creator.
+</commentary>
+</example>
+
 # Explicit sonnet for complex agent generation reasoning
 model: sonnet
 color: magenta


### PR DESCRIPTION
## Summary

Added a 4th example to the `agent-creator` agent demonstrating proactive triggering, where Claude recognizes implicit agent needs without explicit "create an agent" requests.

## Problem

Fixes #121

The `agent-creator` agent had 3 examples all demonstrating reactive triggering patterns. Per Claude Code subagent best practices, agents should also demonstrate proactive triggering to show Claude when to automatically invoke them.

## Solution

Added a new proactive triggering example that shows:
- User describing agent-like functionality without explicitly requesting agent creation
- Assistant recognizing the implicit need and proactively triggering the agent-creator

### Alternatives Considered

- Could add multiple proactive examples, but one well-crafted example suffices
- Could modify existing examples to be proactive, but keeping reactive examples is valuable for explicit requests

## Changes

- `plugins/plugin-dev/agents/agent-creator.md`: Added 4th example demonstrating proactive triggering

## Testing

- [x] Agent validation script passes
- [x] Markdownlint passes
- [x] Example count now 4 (within recommended 2-4 range)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)