### PR TITLE
feat: add debugging-focused example to skill-reviewer agent

### DIFF
--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -29,6 +29,15 @@ Skill description modified, review for triggering effectiveness.
 </commentary>
 </example>
 
+<example>
+Context: User is having trouble with skill triggering
+user: "My skill isn't being loaded when I ask about PDF processing"
+assistant: "I'll use the skill-reviewer agent to analyze why the skill isn't triggering."
+<commentary>
+Skill triggering issue reported, trigger skill-reviewer to diagnose description and trigger phrase quality.
+</commentary>
+</example>
+
 model: inherit
 color: cyan
 tools: Read, Grep, Glob


### PR DESCRIPTION
## Summary

Add a 4th example to the skill-reviewer agent demonstrating the troubleshooting use case when users report skills not triggering correctly.

## Problem

Fixes #122

The skill-reviewer agent has exactly 3 examples (the minimum recommended), all focused on reviewing newly created or modified skills. A common user scenario was missing: **debugging why a skill isn't triggering correctly**.

## Solution

Added a new example demonstrating the debugging/diagnostic scenario:

```markdown
<example>
Context: User is having trouble with skill triggering
user: "My skill isn't being loaded when I ask about PDF processing"
assistant: "I'll use the skill-reviewer agent to analyze why the skill isn't triggering."
<commentary>
Skill triggering issue reported, trigger skill-reviewer to diagnose description and trigger phrase quality.
</commentary>
</example>
```

This extends the agent's coverage to include diagnostic scenarios without changing its core functionality.

### Alternatives Considered

- Adding trigger phrases to description instead of example (but examples are more effective for Claude)
- Creating a separate "skill-debugger" agent (but skill-reviewer's capabilities already cover this)

## Changes

- `plugins/plugin-dev/agents/skill-reviewer.md`: Added 4th example for debugging scenario

## Testing

- [x] Linting passes
- [x] Example follows existing pattern

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)