### PR TITLE
feat: move edge cases section outside code block in agent-creator

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -178,14 +178,15 @@ Validate with: `scripts/validate-agent.sh agents/[identifier].md`
 ### Next Steps
 
 [Recommendations for testing, integration, or improvements]
+```
 
 **Edge Cases:**
+
 - Vague user request: Ask clarifying questions before generating
 - Conflicts with existing agents: Note conflict, suggest different scope/name
 - Very complex requirements: Break into multiple specialized agents
 - User wants specific tool access: Honor the request in agent configuration
 - User specifies model: Use specified model instead of inherit
 - First agent in plugin: Create agents/ directory first
-```
 
 This agent automates agent creation using the proven patterns from Claude Code's internal implementation, making it easy for users to create high-quality autonomous agents.


### PR DESCRIPTION
## Summary

Move edge cases from inside the output format code block to a standalone section, aligning `agent-creator.md` with the patterns used by `plugin-validator.md` and `skill-reviewer.md`.

## Problem

Fixes #127

The `agent-creator.md` agent had its edge cases embedded inside the output format markdown code block (lines 182-188), while the other two agents have edge cases as standalone sections at the end of their system prompts.

This structural inconsistency:
- Makes the agent-creator pattern different from its sibling agents
- Could affect how the LLM processes edge case guidance (inside a code block may be treated as "example output" rather than "instructions to follow")

## Solution

Moved the edge cases from inside the output format code block to a standalone `**Edge Cases:**` section after the code block, matching the pattern in:
- `plugin-validator.md:299-309`
- `skill-reviewer.md:195-201`

### Alternatives Considered

1. **Leave as-is** - The agent works correctly, but inconsistency could cause subtle issues
2. **Update the other agents** - Could move their edge cases inside code blocks instead, but having edge cases as instructions (outside code blocks) is more semantically correct

## Changes

- `plugins/plugin-dev/agents/agent-creator.md`: Close code block after "Next Steps" section, add standalone edge cases section

## Testing

- [x] Linting passes
- [x] Structure matches plugin-validator and skill-reviewer patterns

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)