### PR TITLE
feat: add Glob tool to agent-creator for detecting existing agents

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -41,7 +41,7 @@ User describes agent-like functionality need without explicitly requesting agent
 # Explicit sonnet for complex agent generation reasoning
 model: sonnet
 color: magenta
-tools: Write, Read
+tools: Write, Read, Glob
 skills: agent-development
 ---
 


### PR DESCRIPTION
## Summary

Add `Glob` to the agent-creator's tools list, enabling proactive detection of existing agent files to prevent naming conflicts.

## Problem

Fixes #128

The agent-creator agent's edge cases mention "Conflicts with existing agents: Note conflict, suggest different scope/name" but without `Glob` tool access, the agent cannot proactively scan the `agents/` directory to detect naming conflicts before writing.

## Solution

Added `Glob` to the tools list:
```yaml
tools: Write, Read, Glob
```

This enables the agent to:
- Check if `agents/` directory exists before attempting to create it
- List existing agent files to detect naming conflicts proactively
- Provide better conflict warnings with specific existing agent names

### Alternatives Considered

1. **Leave as-is** - Agent works but can't proactively detect conflicts
2. **Add Bash instead** - Could use `ls` but Glob is more appropriate and follows least-privilege better
3. **Rely on loaded skill** - Skills provide knowledge, not tool access

## Changes

- `plugins/plugin-dev/agents/agent-creator.md`: Added `Glob` to tools list (line 44)

## Testing

- [x] Agent validation passes
- [x] Markdown linting passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)