### PR TITLE
docs: move edge cases section outside code block in skill-reviewer

### DIFF
--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -191,13 +191,14 @@ You are an expert skill architect specializing in reviewing and improving Claude
 1. [Highest priority fix]
 2. [Second priority]
 3. [Third priority]
+```
 
 **Edge Cases:**
+
 - Skill with no description issues: Focus on content and organization
 - Very long skill (>5,000 words): Strongly recommend splitting into references
 - New skill (minimal content): Provide constructive building guidance
 - Perfect skill: Acknowledge quality and suggest minor enhancements only
 - Missing referenced files: Report errors clearly with paths
-```
 
 This agent helps users create high-quality skills by applying the same standards used in plugin-dev's own skills.


### PR DESCRIPTION
## Summary

Moves the Edge Cases section outside the output format code block in `skill-reviewer.md` to clarify that these are operational instructions for the agent, not part of the output template.

## Problem

Fixes #131

The Edge Cases section was embedded inside the output format markdown code block, creating ambiguity about whether it was example output or actual agent instructions.

## Solution

Move the Edge Cases section outside the code block as a separate section, consistent with how `plugin-validator.md` and `agent-creator.md` structure their edge cases.

### Alternatives Considered

- Leaving edge cases in the code block with a comment: Rejected as it still creates ambiguity
- Removing edge cases entirely: Rejected as they provide valuable operational guidance

## Changes

- `plugins/plugin-dev/agents/skill-reviewer.md`: Close code block before Edge Cases section, move Edge Cases outside as standalone section

## Testing

- [x] Linting passes (markdownlint)
- [x] Structure matches other agents (plugin-validator, agent-creator)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)