### PR TITLE
docs: update tools field examples to comma-separated format

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -113,7 +113,7 @@ assistant: "[How assistant should respond and use this agent]"
 
 model: inherit
 color: blue
-tools: ["Read", "Write", "Grep"]
+tools: Read, Write, Grep
 ---
 
 You are [agent role description]...
@@ -225,10 +225,10 @@ Visual identifier for agent in UI.
 
 Restrict agent to specific tools.
 
-**Format:** Array of tool names
+**Format:** Comma-separated tool names
 
 ```yaml
-tools: ["Read", "Write", "Grep", "Bash"]
+tools: Read, Write, Grep, Bash
 ```
 
 **Default:** If omitted, agent has access to all tools
@@ -236,10 +236,10 @@ tools: ["Read", "Write", "Grep", "Bash"]
 **Best practice:** Limit tools to minimum needed (principle of least privilege)
 
 **Common tool sets:**
-- Read-only analysis: `["Read", "Grep", "Glob"]`
-- Code generation: `["Read", "Write", "Grep"]`
-- Testing: `["Read", "Bash", "Grep"]`
-- Full access: Omit field or use `["*"]`
+- Read-only analysis: `Read, Grep, Glob`
+- Code generation: `Read, Write, Grep`
+- Testing: `Read, Bash, Grep`
+- Full access: Omit field entirely
 
 > **Important:** Agents use `tools` while Skills use `allowed-tools`. The field names differ between component types. For skill tool restrictions, see the `skill-development` skill.
 
@@ -438,7 +438,7 @@ Output: [What to provide]
 | description | Yes | Text + examples | Use when... <example>... |
 | model | Yes | inherit/sonnet/opus/haiku | inherit |
 | color | Yes | Color name | blue |
-| tools | No | Array of tool names | ["Read", "Grep"] |
+| tools | No | Comma-separated tool names | Read, Grep |
 
 > **Note:** Agents use `tools` to restrict tool access. Skills use `allowed-tools` for the same purpose. The field names differ between component types.
 


### PR DESCRIPTION
## Summary

Updates the agent-development skill documentation to use comma-separated format for the `tools` field instead of array format, aligning with official Claude Code documentation.

## Problem

Fixes #132

The documentation examples showed array format (`tools: ["Read", "Write"]`) while official Claude Code docs use comma-separated format (`tools: Read, Write`). This inconsistency could confuse users creating agents.

## Solution

Updated all `tools` field examples to use comma-separated format to match:
- Official [sub-agents.md](https://docs.claude.com/en/docs/claude-code/sub-agents) documentation
- Existing agents in this plugin (`plugin-validator.md`, `skill-reviewer.md`, `agent-creator.md`)

### Alternatives Considered

- **Leave as array format**: Rejected because it contradicts official documentation
- **Support both formats**: Not applicable - this is documentation only, not code

## Changes

- `SKILL.md:116` - Complete Format example
- `SKILL.md:228-231` - tools field format description and code block
- `SKILL.md:238-242` - Common tool sets section
- `SKILL.md:441` - Frontmatter Fields Summary table

## Testing

- [x] Markdownlint passes
- [x] Changes are documentation-only (no functional impact)
- [x] Format matches official documentation

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)