### PR TITLE
feat: add disable-model-invocation to workflow commands

### DIFF
--- a/plugins/plugin-dev/commands/create-marketplace.md
+++ b/plugins/plugin-dev/commands/create-marketplace.md
@@ -2,6 +2,7 @@
 description: Create plugin marketplaces with guided workflow
 argument-hint: [marketplace-description]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
+disable-model-invocation: true
 ---
 
 # Marketplace Creation Workflow

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -2,6 +2,7 @@
 description: Create plugins with guided 8-phase workflow
 argument-hint: [plugin-description]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
+disable-model-invocation: true
 ---
 
 # Plugin Creation Workflow


### PR DESCRIPTION
## Summary

Add `disable-model-invocation: true` to the workflow commands to prevent the SlashCommand tool from programmatically invoking these complex 8-phase workflows.

## Problem

Fixes #135

The `/plugin-dev:create-plugin` and `/plugin-dev:create-marketplace` commands are complex 8-phase guided workflows designed for intentional user initiation. Without `disable-model-invocation: true`, Claude could accidentally invoke these commands via the SlashCommand tool during conversation.

## Solution

Added `disable-model-invocation: true` to both command frontmatters, ensuring these workflows can only be initiated by explicit user invocation.

### Alternatives Considered

- **Leave as-is**: Would not address the issue and could lead to UX confusion
- **Document expected behavior**: Less effective than preventing the behavior

## Changes

- `plugins/plugin-dev/commands/create-plugin.md`: Added `disable-model-invocation: true`
- `plugins/plugin-dev/commands/create-marketplace.md`: Added `disable-model-invocation: true`

## Testing

- [x] Markdownlint passes
- [x] Changes are minimal and targeted
- [x] Frontmatter syntax is correct

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)