### PR TITLE
docs: document intentional git scope limitation in workflow commands

### DIFF
--- a/plugins/plugin-dev/commands/create-marketplace.md
+++ b/plugins/plugin-dev/commands/create-marketplace.md
@@ -157,9 +157,16 @@ Guide the user through creating a complete plugin marketplace from initial conce
    - Available plugins table (to be filled in Phase 5)
    - Contributing guidelines (if community)
 
-5. Initialize git repo if creating new directory
+5. Initialize git repo if creating new directory (only `git init` is available; additional git operations like staging and committing are left to the user after the workflow completes to respect their commit preferences)
 
 **Output**: Marketplace directory structure created
+
+**Post-workflow git operations** (user can run after completion):
+
+```bash
+git add .
+git commit -m "feat: initial marketplace structure"
+```
 
 ---
 

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -144,9 +144,16 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
    ```
 5. Create README.md template
 6. Create .gitignore if needed (for .claude/*.local.md, etc.)
-7. Initialize git repo if creating new directory
+7. Initialize git repo if creating new directory (only `git init` is available; additional git operations like staging and committing are left to the user after the workflow completes to respect their commit preferences)
 
 **Output**: Plugin directory structure created and ready for components
+
+**Post-workflow git operations** (user can run after completion):
+
+```bash
+git add .
+git commit -m "feat: initial plugin structure"
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Document that the `allowed-tools` git scope (`git init` only) in workflow commands is intentional
- Add post-workflow git operation examples for users to run after completion

## Problem
Fixes #136

The workflow commands (`create-plugin.md` and `create-marketplace.md`) only allow `Bash(git init:*)` in their `allowed-tools`. Issue #136 raised whether this should be expanded to include `git add`, `git status`, `git commit`, etc.

## Solution
After analysis, the current limitation is **intentionally minimal** (Option C from the issue). This is the correct approach because:

1. **Write tool handles file creation** - Files are created via the Write tool, not bash commands, so `git add` isn't needed mid-workflow
2. **Respects user preferences** - Commit messages, timing, and git workflow vary by team/user
3. **Focus on structure** - The workflow's purpose is structure creation, not managing git history

Rather than expanding git permissions, this PR documents the intentional design and provides post-workflow git examples for users.

### Alternatives Considered
- **Option A** (`Bash(git:*)`): Too permissive - allows destructive operations like `push --force`, `reset --hard`
- **Option B** (add specific subcommands): Unnecessary since Write tool handles file creation

## Changes
- `plugins/plugin-dev/commands/create-plugin.md`: Updated Phase 4 step 7 with explanation, added post-workflow git examples
- `plugins/plugin-dev/commands/create-marketplace.md`: Updated Phase 4 step 5 with explanation, added post-workflow git examples

## Testing
- [x] markdownlint passes
- [x] Changes limited to documentation only
- [x] No functional changes to workflow behavior

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)