### PR TITLE
feat: add explicit model specification to workflow commands

### DIFF
--- a/plugins/plugin-dev/commands/create-marketplace.md
+++ b/plugins/plugin-dev/commands/create-marketplace.md
@@ -2,6 +2,7 @@
 description: Create plugin marketplaces with guided workflow
 argument-hint: [marketplace-description]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
+model: sonnet
 disable-model-invocation: true
 ---
 

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -2,6 +2,7 @@
 description: Create plugins with guided 8-phase workflow
 argument-hint: [plugin-description]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
+model: sonnet
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary
- Add `model: sonnet` frontmatter field to `/plugin-dev:create-plugin` and `/plugin-dev:create-marketplace` commands
- Ensures consistent workflow quality regardless of user's current conversation model

## Problem
Fixes #137

Complex 8-phase workflows inherit model from conversation context, causing inconsistent quality. Users on `haiku` would get different results than those on `opus`.

## Solution
Explicitly specify `model: sonnet` for workflow commands - a good balance of capability and cost for complex multi-step workflows.

### Alternatives Considered
- **Keep inheriting from conversation** (original behavior): Allows user cost/quality control but risks inconsistent results
- **Use `opus`**: Maximum quality but higher cost for 8-phase workflows
- **Use `haiku`**: Faster but may not handle complex design phases well

## Changes
- `plugins/plugin-dev/commands/create-plugin.md`: Added `model: sonnet` to frontmatter
- `plugins/plugin-dev/commands/create-marketplace.md`: Added `model: sonnet` to frontmatter

## Testing
- [x] Linting passes
- [x] No structural changes to command content

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)