### PR TITLE
fix: enable router invocation of workflow commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,15 @@ Hooks defined in `hooks/hooks.json`:
 
 ## Workflow
 
+### `/plugin-dev:start`
+
+The primary entry point for plugin development. Presents users with a choice:
+
+1. **Create a plugin** (recommended for most users) - Routes to `/plugin-dev:create-plugin`
+2. **Create a marketplace** - Routes to `/plugin-dev:create-marketplace`
+
+Use this command when starting fresh or when unsure which workflow to use.
+
 ### `/plugin-dev:create-plugin`
 
 An 8-phase guided workflow for plugin creation:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,17 @@ claude --plugin-dir /path/to/plugin-dev/plugins/plugin-dev
 
 ## Quick Start
 
-### Creating Your First Plugin
+**New to plugin development?** Start with the guided entry point:
+
+```bash
+/plugin-dev:start
+```
+
+This will help you choose between creating a **plugin** (most users) or a **marketplace** (for distributing multiple plugins).
+
+### Learning by Asking
+
+You can also learn progressively by asking questions. Skills load automatically:
 
 1. **Plan your plugin structure:**
    - Ask: "What's the best directory structure for a plugin with commands and MCP integration?"
@@ -76,12 +86,6 @@ claude --plugin-dir /path/to/plugin-dev/plugins/plugin-dev
 3. **Implement hooks (if needed):**
    - Ask: "Create a PreToolUse hook that validates file writes"
    - The hook-development skill gives working examples and utilities
-
-Or use the guided workflow:
-
-```bash
-/plugin-dev:create-plugin A plugin for managing database migrations
-```
 
 ## Skills
 
@@ -110,6 +114,10 @@ Each skill provides:
 For detailed documentation on any skill, ask Claude Code or browse the `skills/` directory.
 
 ## Guided Workflows
+
+### /plugin-dev:start
+
+A guided entry point to help you choose between creating a **plugin** (most users) or a **marketplace** (for distributing multiple plugins).
 
 ### /plugin-dev:create-plugin
 

--- a/plugins/plugin-dev/commands/create-marketplace.md
+++ b/plugins/plugin-dev/commands/create-marketplace.md
@@ -3,7 +3,6 @@ description: Create plugin marketplaces with guided workflow
 argument-hint: [marketplace-description]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
 model: sonnet
-disable-model-invocation: true
 ---
 
 # Marketplace Creation Workflow

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -3,7 +3,6 @@ description: Create plugins with guided 8-phase workflow
 argument-hint: [plugin-description]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(mkdir:*), Bash(git init:*), TodoWrite, AskUserQuestion, Skill, Task
 model: sonnet
-disable-model-invocation: true
 ---
 
 # Plugin Creation Workflow

--- a/plugins/plugin-dev/commands/start.md
+++ b/plugins/plugin-dev/commands/start.md
@@ -1,0 +1,146 @@
+---
+description: Start plugin development - choose your path
+allowed-tools: AskUserQuestion, SlashCommand, TodoWrite
+model: sonnet
+disable-model-invocation: true
+---
+
+# Plugin Development Entry Point
+
+Welcome the user and help them choose the right path for their plugin development journey.
+
+## Your Task
+
+Present the user with a clear choice between two development paths, explain when each is appropriate, then route them to the correct workflow.
+
+## Step 1: Present Options with AskUserQuestion
+
+Use the AskUserQuestion tool to ask the user which path they want to take. Present these options:
+
+**Question**: "What would you like to create?"
+
+**Options**:
+
+1. **A plugin** (Recommended for most users)
+   - Description: "Create a single plugin with skills, commands, agents, hooks, or MCP integrations. Best for: building something new, adding functionality to Claude Code, or learning plugin development."
+
+2. **A marketplace**
+   - Description: "Create a collection to organize and distribute multiple plugins. Best for: teams sharing internal tools, publishing a curated set of plugins, or organizing existing plugins."
+
+## Step 2: Provide Context Before They Choose
+
+Before presenting the question, briefly explain:
+
+```
+Welcome to the Plugin Development Toolkit!
+
+I'll help you get started. First, let me explain your options:
+
+**Plugin** → A self-contained extension that adds functionality to Claude Code
+- Contains skills (knowledge), commands (actions), agents (automation), hooks (events), or MCP servers (integrations)
+- Example: "A plugin for managing database migrations"
+- This is what most developers want to create
+
+**Marketplace** → A collection that organizes and distributes multiple plugins
+- Contains references to one or more plugins (local or remote)
+- Example: "A marketplace for our team's internal tools"
+- Choose this if you already have plugins to organize, or want to plan a collection upfront
+```
+
+## Step 3: Route Based on Choice
+
+After the user selects an option:
+
+**If they chose "A plugin"**:
+- Acknowledge their choice
+- Use the SlashCommand tool to invoke `/plugin-dev:create-plugin`
+- Pass through any context from $ARGUMENTS if provided
+
+**If they chose "A marketplace"**:
+- Acknowledge their choice
+- Use the SlashCommand tool to invoke `/plugin-dev:create-marketplace`
+- Pass through any context from $ARGUMENTS if provided
+
+## Step 4: Handle Arguments
+
+If the user provided arguments ($ARGUMENTS is not empty):
+- Analyze the arguments to see if intent is already clear
+- If arguments clearly indicate a plugin (e.g., "database migration tool"), suggest plugin path
+- If arguments clearly indicate a marketplace (e.g., "team collection", "distribute our plugins"), suggest marketplace path
+- Still ask for confirmation before routing
+
+**Initial request:** $ARGUMENTS
+
+---
+
+## Example Interactions
+
+### Example 1: No arguments provided
+
+```
+User: /plugin-dev:start
+
+Claude: Welcome to the Plugin Development Toolkit!
+
+I'll help you get started. First, let me explain your options:
+
+**Plugin** → A self-contained extension that adds functionality to Claude Code
+- Contains skills (knowledge), commands (actions), agents (automation), hooks (events), or MCP servers (integrations)
+- Example: "A plugin for managing database migrations"
+- This is what most developers want to create
+
+**Marketplace** → A collection that organizes and distributes multiple plugins
+- Contains references to one or more plugins (local or remote)
+- Example: "A marketplace for our team's internal tools"
+- Choose this if you already have plugins to organize, or want to plan a collection upfront
+
+[Uses AskUserQuestion to present the choice]
+```
+
+### Example 2: Arguments suggest a plugin
+
+```
+User: /plugin-dev:start a code review assistant
+
+Claude: Welcome to the Plugin Development Toolkit!
+
+Based on your description "a code review assistant", it sounds like you want to create a **plugin** - a self-contained extension that adds code review functionality to Claude Code.
+
+[Uses AskUserQuestion to confirm: "Does creating a plugin sound right for your needs?"]
+
+User: Yes
+
+Claude: Great! Let me start the plugin creation workflow...
+[Invokes /plugin-dev:create-plugin a code review assistant]
+```
+
+### Example 3: Arguments suggest a marketplace
+
+```
+User: /plugin-dev:start organize our team's internal tools
+
+Claude: Welcome to the Plugin Development Toolkit!
+
+Based on your description "organize our team's internal tools", it sounds like you want to create a **marketplace** - a collection to distribute plugins to your team.
+
+[Uses AskUserQuestion to confirm: "Does creating a marketplace sound right for your needs?"]
+
+User: Yes
+
+Claude: Great! Let me start the marketplace creation workflow...
+[Invokes /plugin-dev:create-marketplace organize our team's internal tools]
+```
+
+---
+
+## Important Notes
+
+- Always present both options clearly before asking
+- If arguments are provided, analyze them but still confirm before routing
+- Use a friendly, welcoming tone - this is the user's first interaction
+- The goal is to help users quickly get to the right workflow, not to slow them down
+- If users ask questions instead of choosing, answer briefly and guide them back to the choice
+
+---
+
+Begin by presenting the welcome message and using AskUserQuestion to help the user choose their path.


### PR DESCRIPTION
## Summary

Enable the `/plugin-dev:start` router command to successfully invoke child workflows by removing `disable-model-invocation: true` from target commands.

## Problem

Fixes #143

The `/plugin-dev:start` router uses `SlashCommand` tool to invoke child workflows (`/plugin-dev:create-plugin` or `/plugin-dev:create-marketplace`). However, both target commands had `disable-model-invocation: true` set, which per [official documentation](https://code.claude.com/docs/en/slash-commands.md) blocks programmatic invocation via the SlashCommand tool.

## Solution

Apply the correct protection pattern:
- **Entry point** (`start.md`) has `disable-model-invocation: true` ✅
- **Child commands** are invocable internally via SlashCommand tool

Removed `disable-model-invocation: true` from both child commands to allow the router pattern to work.

### Alternatives Considered

1. **Remove router entirely**: Would lose the user-friendly entry point that helps new users choose the right workflow
2. **Direct user to manually invoke commands**: Poor UX - defeats the purpose of having a guided router
3. **Remove all disable-model-invocation flags**: Would lose protection on the entry point

## Changes

- `plugins/plugin-dev/commands/create-plugin.md`: Remove `disable-model-invocation: true`
- `plugins/plugin-dev/commands/create-marketplace.md`: Remove `disable-model-invocation: true`
- `plugins/plugin-dev/commands/start.md`: Add new router command (was untracked)
- `CLAUDE.md`: Document the new `/plugin-dev:start` command
- `README.md`: Document the new entry point workflow

## Testing

- [x] Markdownlint passes
- [x] Verified frontmatter structure is valid
- [ ] Manual test: Load plugin and run `/plugin-dev:start`, select plugin → should invoke create-plugin
- [ ] Manual test: Load plugin and run `/plugin-dev:start`, select marketplace → should invoke create-marketplace

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)