### PR TITLE
chore: prepare release v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Unofficial plugin-dev plugin marketplace for plugin-dev Claude Code plugin - the plugin itself was initially created by Daisy Hollman at Anthropic.",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "plugin-dev",
       "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 8 expert skills covering hooks, MCP integration, commands, agents, marketplaces, and best practices. AI-assisted plugin creation and validation.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Daisy Hollman",
         "url": "https://github.com/anthropics/claude-code/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-12-12
+
+### Added
+
+- **`/plugin-dev:start` command** - New primary entry point that guides users to choose between creating a plugin or marketplace (#145)
+  - Uses `disable-model-invocation: true` to route cleanly to specialized workflows
+  - Recommends plugin creation for most users
+
+### Fixed
+
+- Enable router invocation of workflow commands - workflow commands can now be invoked by other commands (#145)
+- Replace `!` with `[BANG]` placeholder in skill documentation to prevent shell interpretation issues (#142)
+
+### Documentation
+
+- Fix component counts and update documentation accuracy across README, CONTRIBUTING, CLAUDE.md, and marketplace.json
+
 ## [0.1.0] - 2025-12-11
 
 ### Added
@@ -109,5 +126,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Based on original plugin by Daisy Hollman at Anthropic
 - Expanded with enhanced skills, additional utilities, and CI/CD infrastructure
 
-[Unreleased]: https://github.com/sjnims/plugin-dev/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/sjnims/plugin-dev/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sjnims/plugin-dev/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/sjnims/plugin-dev/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This repository is a **plugin marketplace** containing the **plugin-dev** plugin
 
 ## Quick Reference
 
-**Current Version**: v0.1.0 (see [CHANGELOG.md](CHANGELOG.md) for release history)
+**Current Version**: v0.2.0 (see [CHANGELOG.md](CHANGELOG.md) for release history)
 
 ## Repository Structure
 

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-dev",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 8 expert skills covering hooks, MCP integration, commands, agents, marketplaces, and best practices. AI-assisted plugin creation and validation.",
   "author": {
     "name": "Daisy Hollman",


### PR DESCRIPTION
## Summary

- Version bump to v0.2.0
- Update version in plugin.json, marketplace.json, and CLAUDE.md
- Add CHANGELOG entry for v0.2.0 release

## What's in v0.2.0

### Added
- **`/plugin-dev:start` command** - New primary entry point that guides users to choose between creating a plugin or marketplace (#145)

### Fixed
- Enable router invocation of workflow commands (#145)
- Replace `!` with `[BANG]` placeholder in skill documentation (#142)

### Documentation
- Fix component counts and update documentation accuracy

## Checklist
- [x] Version updated in plugin.json, marketplace.json, CLAUDE.md
- [x] CHANGELOG.md updated with release notes
- [x] Markdownlint passes
- [x] Version consistency verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)