### PR TITLE
docs: add prerequisites section for utility script dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,31 @@ Each component follows progressive disclosure: lean core documentation with deta
 
 ## Prerequisites
 
+### Required
+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
-- Bash shell (for utility scripts)
 - Git (for version control and marketplace publishing)
+
+### For Utility Scripts
+
+The plugin includes utility scripts for validation and testing. These require:
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| bash | 3.2+ | Shell scripting (macOS default works) |
+| jq | 1.6+ | JSON parsing and validation |
+| grep | - | Pattern matching (with `-E` support) |
+| sed | - | Stream editing (GNU or BSD) |
+
+**Check your environment:**
+
+```bash
+bash --version | head -1
+jq --version
+grep --version 2>&1 | head -1
+```
+
+> **Note**: `jq` may need to be installed. macOS: `brew install jq`, Linux: `apt install jq`
 
 ## Installation
 

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -695,6 +695,8 @@ Working examples in `examples/`:
 
 ### Utility Scripts
 
+> **Prerequisites**: These scripts require `jq` for JSON validation. See the [main README](../../../../README.md#for-utility-scripts) for setup.
+
 Development tools in `scripts/`:
 
 - **`validate-hook-schema.sh`** - Validate hooks.json structure and syntax


### PR DESCRIPTION
## Description

Add documentation for utility script dependencies (jq, grep, sed) so users know what tools are required before running validation scripts.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)
- [x] Documentation (README.md, CLAUDE.md, SECURITY.md)

## Motivation and Context

Users may encounter confusing errors if external tools like `jq` are missing. This documents the requirements upfront.

Fixes #152

## Solution

- **README.md**: Added "For Utility Scripts" subsection to Prerequisites with tool/version table, environment check commands, and installation note
- **hook-development/SKILL.md**: Added prerequisites blockquote referencing the main README

### Note on Bash Version

The issue originally suggested bash 4.0+ but I verified the scripts only use `[[ =~ ]]` regex matching which is available in bash 3.2+ (macOS default). Updated accordingly.

## Changes

- `README.md`: Added utility script prerequisites section
- `plugins/plugin-dev/skills/hook-development/SKILL.md`: Added prerequisites note

## Testing

- [x] Linting passes (markdownlint)
- [x] Verified bash version requirement by grepping for 4.0+ features (none found)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)