### PR TITLE
docs: use secure mktemp pattern instead of predictable temp files

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/references/parsing-techniques.md
+++ b/plugins/plugin-dev/skills/plugin-settings/references/parsing-techniques.md
@@ -198,8 +198,9 @@ Always use temp file + atomic move to prevent corruption:
 FILE=".claude/my-plugin.local.md"
 NEW_VALUE="updated_value"
 
-# Create temp file
-TEMP_FILE="${FILE}.tmp.$$"
+# Create secure temp file (unpredictable name)
+TEMP_FILE=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
+trap 'rm -f "$TEMP_FILE"' EXIT
 
 # Update field using sed
 sed "s/^field_name: .*/field_name: $NEW_VALUE/" "$FILE" > "$TEMP_FILE"
@@ -215,8 +216,8 @@ mv "$TEMP_FILE" "$FILE"
 CURRENT=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
 NEXT=$((CURRENT + 1))
 
-# Update file
-TEMP_FILE="${FILE}.tmp.$$"
+# Update file (secure temp file)
+TEMP_FILE=$(mktemp) || exit 1
 sed "s/^iteration: .*/iteration: $NEXT/" "$FILE" > "$TEMP_FILE"
 mv "$TEMP_FILE" "$FILE"
 ```
@@ -224,8 +225,8 @@ mv "$TEMP_FILE" "$FILE"
 ### Update Multiple Fields
 
 ```bash
-# Update several fields at once
-TEMP_FILE="${FILE}.tmp.$$"
+# Update several fields at once (secure temp file)
+TEMP_FILE=$(mktemp) || exit 1
 
 sed -e "s/^iteration: .*/iteration: $NEXT_ITERATION/" \
     -e "s/^pr_number: .*/pr_number: $PR_NUMBER/" \

--- a/plugins/plugin-dev/skills/plugin-settings/references/real-world-examples.md
+++ b/plugins/plugin-dev/skills/plugin-settings/references/real-world-examples.md
@@ -200,8 +200,8 @@ NEXT_ITERATION=$((ITERATION + 1))
 # Extract prompt from markdown body
 PROMPT_TEXT=$(awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE")
 
-# Update iteration counter
-TEMP_FILE="${RALPH_STATE_FILE}.tmp.$$"
+# Update iteration counter (secure temp file)
+TEMP_FILE=$(mktemp) || exit 1
 sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$RALPH_STATE_FILE" > "$TEMP_FILE"
 mv "$TEMP_FILE" "$RALPH_STATE_FILE"
 
@@ -292,12 +292,12 @@ enabled: true
 Both use temp file + atomic move:
 
 ```bash
-TEMP_FILE="${FILE}.tmp.$$"
+TEMP_FILE=$(mktemp) || exit 1
 sed "s/^field: .*/field: $NEW_VALUE/" "$FILE" > "$TEMP_FILE"
 mv "$TEMP_FILE" "$FILE"
 ```
 
-**Why:** Prevents corruption if process is interrupted.
+**Why:** Prevents corruption if process is interrupted. Using `mktemp` creates a secure, unpredictable filename.
 
 ### 4. Quote Handling
 
@@ -355,8 +355,8 @@ echo "$VALUE"
 # BAD: Can corrupt file if interrupted
 sed -i "s/field: .*/field: $VALUE/" "$FILE"
 
-# GOOD: Atomic
-TEMP_FILE="${FILE}.tmp.$$"
+# GOOD: Atomic with secure temp file
+TEMP_FILE=$(mktemp) || exit 1
 sed "s/field: .*/field: $VALUE/" "$FILE" > "$TEMP_FILE"
 mv "$TEMP_FILE" "$FILE"
 ```


### PR DESCRIPTION
## Description

Replace predictable temp file pattern `${FILE}.tmp.$$` with secure `mktemp` pattern in documentation examples.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

The `${FILE}.tmp.$$` pattern is a known security anti-pattern because:
- `$$` (PID) is predictable and can be enumerated
- Attackers could pre-create symlinks to sensitive files
- Race conditions between check and use

While this is documentation (not executable code), it teaches developers patterns they might copy into production scripts.

Fixes #153

## Solution

Replaced all 6 instances with secure `mktemp` pattern:

```bash
TEMP_FILE=$(mktemp) || exit 1
```

## Changes

| File | Instances |
|------|-----------|
| `parsing-techniques.md` | 3 (lines 202, 219, 228) |
| `real-world-examples.md` | 3 (lines 204, 295, 359) |

## Testing

- [x] Linting passes (markdownlint)
- [x] Verified no remaining `${FILE}.tmp.$$` patterns

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)