### PR TITLE
refactor: use ERE instead of BRE in grep patterns for clarity

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -197,13 +197,13 @@ else
   fi
 
   # Check for second person
-  if ! echo "$SYSTEM_PROMPT" | grep -q "You are\|You will\|Your"; then
+  if ! echo "$SYSTEM_PROMPT" | grep -Eq "You are|You will|Your"; then
     echo "⚠️  System prompt should use second person (You are..., You will...)"
     ((warning_count++))
   fi
 
   # Check for structure
-  if ! echo "$SYSTEM_PROMPT" | grep -qi "responsibilities\|process\|steps"; then
+  if ! echo "$SYSTEM_PROMPT" | grep -Eqi "responsibilities|process|steps"; then
     echo "💡 Consider adding clear responsibilities or process steps"
   fi
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
@@ -53,13 +53,13 @@ check_script() {
   fi
 
   # Check 4: Reads from stdin
-  if ! grep -q "cat\|read" "$script"; then
+  if ! grep -Eq "cat|read" "$script"; then
     echo "⚠️  Doesn't appear to read input from stdin"
     ((warnings++))
   fi
 
   # Check 5: Uses jq for JSON parsing
-  if grep -q "tool_input\|tool_name" "$script" && ! grep -q "jq" "$script"; then
+  if grep -Eq "tool_input|tool_name" "$script" && ! grep -q "jq" "$script"; then
     echo "⚠️  Parses hook input but doesn't use jq"
     ((warnings++))
   fi
@@ -79,19 +79,19 @@ check_script() {
   fi
 
   # Check 8: Uses CLAUDE_PLUGIN_ROOT
-  if ! grep -q "CLAUDE_PLUGIN_ROOT\|CLAUDE_PROJECT_DIR" "$script"; then
+  if ! grep -Eq "CLAUDE_PLUGIN_ROOT|CLAUDE_PROJECT_DIR" "$script"; then
     echo "💡 Tip: Use \$CLAUDE_PLUGIN_ROOT for plugin-relative paths"
   fi
 
   # Check 9: Exit codes
-  if ! grep -q "exit 0\|exit 2" "$script"; then
+  if ! grep -Eq "exit 0|exit 2" "$script"; then
     echo "⚠️  No explicit exit codes (should exit 0 or 2)"
     ((warnings++))
   fi
 
   # Check 10: JSON output for decision hooks
-  if grep -q "PreToolUse\|Stop" "$script"; then
-    if ! grep -q "permissionDecision\|decision" "$script"; then
+  if grep -Eq "PreToolUse|Stop" "$script"; then
+    if ! grep -Eq "permissionDecision|decision" "$script"; then
       echo "💡 Tip: PreToolUse/Stop hooks should output decision JSON"
     fi
   fi
@@ -104,7 +104,7 @@ check_script() {
   fi
 
   # Check 12: Error messages to stderr
-  if grep -q 'echo.*".*error\|Error\|denied\|Denied' "$script"; then
+  if grep -Eq 'echo.*".*error|Error|denied|Denied' "$script"; then
     if ! grep -q '>&2' "$script"; then
       echo "⚠️  Error messages should be written to stderr (>&2)"
       ((warnings++))
@@ -112,7 +112,7 @@ check_script() {
   fi
 
   # Check 13: Input validation
-  if ! grep -q "if.*empty\|if.*null\|if.*-z" "$script"; then
+  if ! grep -Eq "if.*empty|if.*null|if.*-z" "$script"; then
     echo "💡 Tip: Consider validating input fields aren't empty"
   fi
 


### PR DESCRIPTION
## Description

Replace BRE (Basic Regular Expression) patterns with ERE (Extended Regular Expression) in grep commands for improved readability.

## Type of Change

- [x] Refactoring (code change that neither fixes a bug nor adds a feature)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

BRE with escaped alternation (`grep -q "a\|b"`) is harder to read than ERE (`grep -Eq "a|b"`). The escaped pipes are:
- Easy to forget or get wrong
- Less widely understood
- May behave differently across grep implementations

Fixes #154

## Solution

Changed `grep -q` to `grep -Eq` for patterns with alternation, removing the backslash escapes.

## Changes

| File | Instances |
|------|-----------|
| `validate-agent.sh` | 2 |
| `hook-linter.sh` | 9 |

**Total: 11 instances**

## Testing

- [x] shellcheck passes on both modified scripts
- [x] Verified no BRE alternation patterns remain

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)