### PR TITLE
docs: add shellcheck guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,38 @@ Current branch: [BANG]`git branch --show-current`
 - Command files (`.claude/commands/*.md`) use actual `!` syntax
 - See [SECURITY.md](SECURITY.md#shell-pattern-escaping-with-bang-placeholder) for full details
 
+### Shell Script Quality
+
+All shell scripts should pass [shellcheck](https://www.shellcheck.net/) validation:
+
+```bash
+# Check all plugin scripts
+shellcheck plugins/plugin-dev/skills/*/scripts/*.sh
+
+# Check a specific script
+shellcheck plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+```
+
+#### Handling Intentional Patterns
+
+If a pattern intentionally triggers a shellcheck warning, add a directive comment:
+
+```bash
+# shellcheck disable=SC2086  # Word splitting intended for arguments
+command $unquoted_var
+```
+
+Always include a comment explaining why the directive is needed.
+
+#### Common Issues
+
+| Warning | Typical Fix |
+|---------|-------------|
+| SC2086 | Quote variables: `"$var"` |
+| SC2046 | Quote command substitution: `"$(cmd)"` |
+| SC2034 | Remove unused variables or export them |
+| SC2155 | Separate declaration and assignment: `local var; var=$(cmd)` |
+
 ## Component-Specific Guidelines
 
 ### Commands (`/plugin-dev:*`)


### PR DESCRIPTION
## Description

Add "Shell Script Quality" section to CONTRIBUTING.md documenting shellcheck requirements and best practices for contributors.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Documentation (README.md, CLAUDE.md, SECURITY.md)

## Motivation and Context

The plugin contains numerous shell scripts but there was no documented guidance for contributors on:
- Running shellcheck before submitting PRs
- Expected shellcheck compliance level
- How to handle intentional patterns that trigger warnings

CLAUDE.md mentions shellcheck in the Linting section, but CONTRIBUTING.md didn't reference this or explain expectations.

Fixes #155

## Solution

Added "Shell Script Quality" subsection under Development Guidelines with:
- Commands to run shellcheck on plugin scripts
- How to add `# shellcheck disable=SCXXXX` directives for intentional patterns
- Common issues table (SC2086, SC2046, SC2034, SC2155)

## Changes

- `CONTRIBUTING.md`: Added new "Shell Script Quality" section

## Testing

- [x] Linting passes (markdownlint)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)