### PR TITLE
docs: minor script and documentation improvements from security review

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -689,6 +689,8 @@ For detailed patterns and advanced techniques, consult:
 
 Working examples in `examples/`:
 
+> **Note:** After copying example scripts, make them executable: `chmod +x script.sh`
+
 - **`validate-write.sh`** - File write validation example
 - **`validate-bash.sh`** - Bash command validation example
 - **`load-context.sh`** - SessionStart context loading example

--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -169,8 +169,8 @@ if [[ "$TEST_INPUT" =~ [\;\|\&\`\$\(\)\{\}\<\>] ]]; then
   exit 1
 fi
 
-# Validate test input JSON
-if ! jq empty "$TEST_INPUT" 2>/dev/null; then
+# Validate test input JSON (with timeout for defensive consistency)
+if ! timeout 5 jq empty "$TEST_INPUT" 2>/dev/null; then
   echo "❌ Error: Test input is not valid JSON"
   exit 1
 fi

--- a/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Example hook that reads plugin settings from .claude/my-plugin.local.md
+# Example hook that reads plugin settings from .claude/<plugin>.local.md
 # Demonstrates the complete pattern for settings-driven hook behavior
 
 set -euo pipefail
 
-# Define settings file path
-SETTINGS_FILE=".claude/my-plugin.local.md"
+# Define settings file path using environment variable with default
+# This allows the plugin name to be configured externally if needed
+PLUGIN_NAME="${PLUGIN_NAME:-my-plugin}"
+SETTINGS_FILE=".claude/${PLUGIN_NAME}.local.md"
 
 # Quick exit if settings file doesn't exist
 if [[ ! -f "$SETTINGS_FILE" ]]; then

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Frontmatter Parser Utility
 # Extracts YAML frontmatter from .local.md files
+#
+# Note: This script assumes the settings file is stable (not being written to).
+# Settings changes require a Claude Code restart to take effect, so there's no
+# need for file locking in normal usage.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Batch of four low-priority improvements identified during a comprehensive security review. These are minor quality enhancements that improve usability and defensive coding practices.

## Problem

Fixes #163

1. **chmod reminder missing** - Users copying example scripts encounter permission errors
2. **Hardcoded plugin name** - Example doesn't teach portable pattern
3. **Missing jq timeout** - Inconsistent with defensive patterns elsewhere in script
4. **Undocumented file stability assumption** - Settings parsing assumes stable files

## Solution

### Item 1: chmod reminder (SKILL.md)
Added note in "Example Hook Scripts" section:
> **Note:** After copying example scripts, make them executable: `chmod +x script.sh`

### Item 2: Parameterized plugin name (read-settings-hook.sh)
Changed from:
```bash
SETTINGS_FILE=".claude/my-plugin.local.md"
```
To:
```bash
PLUGIN_NAME="${PLUGIN_NAME:-my-plugin}"
SETTINGS_FILE=".claude/${PLUGIN_NAME}.local.md"
```

### Item 3: jq timeout (test-hook.sh)
Changed from:
```bash
if ! jq empty "$TEST_INPUT" 2>/dev/null; then
```
To:
```bash
if ! timeout 5 jq empty "$TEST_INPUT" 2>/dev/null; then
```

### Item 4: Race condition documentation (parse-frontmatter.sh)
Added comment explaining file stability assumption and that changes require restart.

### Alternatives Considered

None - all changes follow the suggestions in the issue exactly.

## Changes

| File | Change |
|------|--------|
| `hook-development/SKILL.md` | Added chmod reminder note |
| `plugin-settings/examples/read-settings-hook.sh` | Parameterized plugin name |
| `hook-development/scripts/test-hook.sh` | Added timeout to jq validation |
| `plugin-settings/scripts/parse-frontmatter.sh` | Documented file stability assumption |

## Testing

- [x] shellcheck passes on all modified scripts (pre-existing info-level warnings unrelated to changes)
- [x] markdownlint passes on modified markdown
- [x] Changes are backwards compatible (parameterized name defaults to original)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)