### PR TITLE
fix: resolve shellcheck SC1087 errors in validate-hook-schema.sh

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -69,7 +69,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
     # Check matcher exists
     matcher=$(jq -r ".\"$event\"[$i].matcher // empty" "$HOOKS_FILE")
     if [ -z "$matcher" ]; then
-      echo "❌ $event[$i]: Missing 'matcher' field"
+      echo "❌ ${event}[$i]: Missing 'matcher' field"
       ((error_count++))
       continue
     fi
@@ -77,7 +77,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
     # Check hooks array exists
     hooks=$(jq -r ".\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
     if [ -z "$hooks" ] || [ "$hooks" = "null" ]; then
-      echo "❌ $event[$i]: Missing 'hooks' array"
+      echo "❌ ${event}[$i]: Missing 'hooks' array"
       ((error_count++))
       continue
     fi
@@ -89,13 +89,13 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
       hook_type=$(jq -r ".\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
 
       if [ -z "$hook_type" ]; then
-        echo "❌ $event[$i].hooks[$j]: Missing 'type' field"
+        echo "❌ ${event}[$i].hooks[$j]: Missing 'type' field"
         ((error_count++))
         continue
       fi
 
       if [ "$hook_type" != "command" ] && [ "$hook_type" != "prompt" ]; then
-        echo "❌ $event[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command' or 'prompt')"
+        echo "❌ ${event}[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command' or 'prompt')"
         ((error_count++))
         continue
       fi
@@ -104,25 +104,25 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
       if [ "$hook_type" = "command" ]; then
         command=$(jq -r ".\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
         if [ -z "$command" ]; then
-          echo "❌ $event[$i].hooks[$j]: Command hooks must have 'command' field"
+          echo "❌ ${event}[$i].hooks[$j]: Command hooks must have 'command' field"
           ((error_count++))
         else
           # Check for hardcoded paths
           if [[ "$command" == /* ]] && [[ "$command" != *'${CLAUDE_PLUGIN_ROOT}'* ]]; then
-            echo "⚠️  $event[$i].hooks[$j]: Hardcoded absolute path detected. Consider using \${CLAUDE_PLUGIN_ROOT}"
+            echo "⚠️  ${event}[$i].hooks[$j]: Hardcoded absolute path detected. Consider using \${CLAUDE_PLUGIN_ROOT}"
             ((warning_count++))
           fi
         fi
       elif [ "$hook_type" = "prompt" ]; then
         prompt=$(jq -r ".\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
         if [ -z "$prompt" ]; then
-          echo "❌ $event[$i].hooks[$j]: Prompt hooks must have 'prompt' field"
+          echo "❌ ${event}[$i].hooks[$j]: Prompt hooks must have 'prompt' field"
           ((error_count++))
         fi
 
         # Check if prompt-based hooks are used on supported events
         if [ "$event" != "Stop" ] && [ "$event" != "SubagentStop" ] && [ "$event" != "UserPromptSubmit" ] && [ "$event" != "PreToolUse" ]; then
-          echo "⚠️  $event[$i].hooks[$j]: Prompt hooks may not be fully supported on $event (best on Stop, SubagentStop, UserPromptSubmit, PreToolUse)"
+          echo "⚠️  ${event}[$i].hooks[$j]: Prompt hooks may not be fully supported on $event (best on Stop, SubagentStop, UserPromptSubmit, PreToolUse)"
           ((warning_count++))
         fi
       fi
@@ -131,13 +131,13 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
       timeout=$(jq -r ".\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
       if [ -n "$timeout" ] && [ "$timeout" != "null" ]; then
         if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
-          echo "❌ $event[$i].hooks[$j]: Timeout must be a number"
+          echo "❌ ${event}[$i].hooks[$j]: Timeout must be a number"
           ((error_count++))
         elif [ "$timeout" -gt 600 ]; then
-          echo "⚠️  $event[$i].hooks[$j]: Timeout $timeout seconds is very high (max 600s)"
+          echo "⚠️  ${event}[$i].hooks[$j]: Timeout $timeout seconds is very high (max 600s)"
           ((warning_count++))
         elif [ "$timeout" -lt 5 ]; then
-          echo "⚠️  $event[$i].hooks[$j]: Timeout $timeout seconds is very low"
+          echo "⚠️  ${event}[$i].hooks[$j]: Timeout $timeout seconds is very low"
           ((warning_count++))
         fi
       fi


### PR DESCRIPTION
## Summary

Fix shellcheck SC1087 errors by replacing unbraced variable syntax `$event[$i]` with proper brace expansion `${event}[$i]` in 11 locations.

## Problem

Fixes #167

The `validate-hook-schema.sh` utility script used `$event[$i]` syntax which shellcheck interprets as array access without braces. While bash handles this correctly (since `$event` is a scalar), shellcheck flags it as an error.

## Solution

Replace all instances of:
- `$event[$i]:` → `${event}[$i]:`
- `$event[$i].hooks[$j]:` → `${event}[$i].hooks[$j]:`

This brings the script into compliance with shellcheck and aligns with the project's code quality standards per CONTRIBUTING.md.

### Alternatives Considered

- **Disable shellcheck rule**: Rejected because SC1087 is a reasonable lint rule and the fix is trivial.
- **No change**: Rejected because the project expects shellcheck compliance.

## Changes

- `plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh`: 11 substitutions

## Testing

- [x] `shellcheck --severity=warning` passes (exit code 0)
- [x] Script behavior unchanged (cosmetic fix only)
- [x] No other files affected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)