### PR TITLE
fix: remove deprecated mode parameter from claude-pr-review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,7 +44,6 @@ jobs:
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          mode: agent
           track_progress: true
           prompt: |
             Review this pull request for the plugin-dev Claude Code plugin.


### PR DESCRIPTION
## Summary

- Removes the deprecated `mode: agent` parameter from the claude-pr-review workflow

## Details

The `mode` parameter was removed in `claude-code-action` v1.0.23 (merged in PR #170). The action now uses intelligent auto-detection to determine the appropriate execution mode based on workflow context.

This was causing the following warning in CI:
```
##[warning]Unexpected input(s) 'mode', valid inputs are [...]
```

## Test plan

- [ ] CI passes without the warning about unexpected `mode` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)