### PR TITLE
chore: prepare release v0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Unofficial plugin-dev plugin marketplace for plugin-dev Claude Code plugin - the plugin itself was initially created by Daisy Hollman at Anthropic.",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "plugins": [
     {
       "name": "plugin-dev",
       "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 8 expert skills covering hooks, MCP integration, commands, agents, marketplaces, and best practices. AI-assisted plugin creation and validation.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Daisy Hollman",
         "url": "https://github.com/anthropics/claude-code/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-12-13
+
+### Security
+
+- **Harden validation scripts against bypass attacks** - Improved input validation and escaping in hook validation scripts (#164)
+- **Prevent command injection in test-hook.sh** - Fixed potential command injection vulnerability (#148)
+- **Use jq for safe JSON output** - Replaced echo with jq for proper JSON escaping in example hooks (#149)
+- **Document security scope and trust model** - Added comprehensive security documentation for workflow commands (#165)
+
+### Fixed
+
+- **Workflow reliability improvements** - Enhanced workflow security, reliability, and documentation
+- **Remove deprecated mode parameter** - Fixed claude-pr-review workflow by removing deprecated mode parameter (#171)
+- **Shellcheck SC1087 errors** - Resolved array expansion errors in validate-hook-schema.sh (#168)
+- **Replace unofficial `cc` alias** - Updated to use official `claude` CLI command
+- **Issue and PR template improvements** - Fixed UX issues, restored spacing, removed unsupported fields
+- **Labels configuration** - Corrected labels.yml and LABELS.md issues
+- **Dependabot configuration** - Improved grouping and accountability settings
+- **Suppress grep stderr** - Fixed noisy output in test-agent-trigger.sh (#150)
+
+### Changed
+
+- **Use ERE instead of BRE** - Refactored grep patterns to use Extended Regular Expressions for clarity (#159)
+
+### Documentation
+
+- **Comprehensive documentation improvements** - Major updates across README, CLAUDE.md, and skill documentation
+- **Discussion templates** - Improved UX with plugin-specific fields
+- **Prerequisites section** - Added utility script dependency documentation (#157)
+- **Shellcheck guidance** - Added linting instructions to CONTRIBUTING.md (#160)
+- **Secure mktemp pattern** - Documented secure temporary file handling (#158)
+- **[BANG] workaround** - Documented security workaround for Claude Code #12781 (#156)
+
+### Dependencies
+
+- Bump anthropics/claude-code-action (#170)
+- Bump EndBug/label-sync (#169)
+- Update GitHub Actions to latest versions
+- Remove deprecated sync-labels.sh script
+
 ## [0.2.0] - 2025-12-12
 
 ### Added
@@ -126,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Based on original plugin by Daisy Hollman at Anthropic
 - Expanded with enhanced skills, additional utilities, and CI/CD infrastructure
 
-[Unreleased]: https://github.com/sjnims/plugin-dev/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/sjnims/plugin-dev/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/sjnims/plugin-dev/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/sjnims/plugin-dev/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/sjnims/plugin-dev/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This repository is a **plugin marketplace** containing the **plugin-dev** plugin
 
 ## Quick Reference
 
-**Current Version**: v0.2.0 (see [CHANGELOG.md](CHANGELOG.md) for release history)
+**Current Version**: v0.2.1 (see [CHANGELOG.md](CHANGELOG.md) for release history)
 
 ### Quick Links
 

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-dev",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 8 expert skills covering hooks, MCP integration, commands, agents, marketplaces, and best practices. AI-assisted plugin creation and validation.",
   "author": {
     "name": "Daisy Hollman",


### PR DESCRIPTION
## Summary

Prepare release v0.2.1 with security hardening, bug fixes, and documentation improvements.

## Changes

### Security
- Harden validation scripts against bypass attacks (#164)
- Prevent command injection in test-hook.sh (#148)
- Use jq for safe JSON output in example hooks (#149)
- Document security scope and trust model (#165)

### Fixed
- Remove deprecated mode parameter from claude-pr-review workflow (#171)
- Resolve shellcheck SC1087 errors in validate-hook-schema.sh (#168)
- Replace unofficial `cc` alias with official `claude` CLI command
- Issue/PR template improvements and labels configuration fixes

### Documentation
- Comprehensive documentation improvements across README, CLAUDE.md, and skills
- Added prerequisites section, shellcheck guidance, secure mktemp patterns

### Dependencies
- Updated anthropics/claude-code-action and EndBug/label-sync
- Updated GitHub Actions to latest versions

## Checklist
- [x] Version updated in plugin.json (0.2.1)
- [x] Version updated in marketplace.json (metadata.version AND plugins[0].version)
- [x] Version updated in CLAUDE.md
- [x] CHANGELOG.md updated with release notes
- [x] Markdownlint passes
- [x] Version consistency verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)