### PR TITLE
feat: add plugin-dev-guide meta-skill for skill navigation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Unofficial plugin-dev plugin marketplace. Originally created by Daisy Hollman at Anthropic, now maintained by Steve Nims.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "plugins": [
     {
       "name": "plugin-dev",
       "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 10 expert skills covering hooks, MCP integration, LSP servers, commands, agents, marketplaces, and best practices, plus a guide skill for navigation. AI-assisted plugin creation and validation.",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "author": {
         "name": "Steve Nims",
         "url": "https://github.com/sjnims"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ Guidance for Claude Code working in this repository.
 
 ## What This Is
 
-Plugin marketplace containing the **plugin-dev** plugin - a toolkit for developing Claude Code plugins. Provides 9 skills, 3 agents, 3 slash commands.
+Plugin marketplace containing the **plugin-dev** plugin - a toolkit for developing Claude Code plugins. Provides 10 skills, 3 agents, 4 slash commands.
 
-**Version**: v0.3.2 | [CHANGELOG.md](CHANGELOG.md)
+**Version**: v0.3.3 | [CHANGELOG.md](CHANGELOG.md)
 
 ## MCP Tool Requirements (CRITICAL)
 

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-dev",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 10 expert skills covering hooks, MCP integration, LSP servers, commands, agents, marketplaces, and best practices, plus a guide skill for navigation. AI-assisted plugin creation and validation.",
   "author": {
     "name": "Steve Nims",

--- a/plugins/plugin-dev/commands/plugin-dev-guide.md
+++ b/plugins/plugin-dev/commands/plugin-dev-guide.md
@@ -1,6 +1,8 @@
 ---
 description: Get an overview of plugin development capabilities and skill routing
 argument-hint: [question or task]
+allowed-tools: Skill, AskUserQuestion
+model: sonnet
 ---
 
 Invoke the plugin-dev:plugin-dev-guide skill to load plugin development guidance.

--- a/plugins/plugin-dev/skills/plugin-dev-guide/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-dev-guide/SKILL.md
@@ -9,7 +9,7 @@ This meta-skill provides an overview of Claude Code plugin development and route
 
 ## Plugin Development Skills Overview
 
-The plugin-dev toolkit provides 9 specialized skills for building Claude Code plugins. Each skill handles a specific domain of plugin development.
+The plugin-dev toolkit provides 9 specialized skills for building Claude Code plugins, plus this guide. Each skill handles a specific domain of plugin development.
 
 ### Skill Quick Reference
 


### PR DESCRIPTION
## Summary

Adds a guide skill that helps users navigate the 9 specialized plugin-dev skills, routing them to the appropriate skill based on their task.

- New `plugin-dev-guide` skill with decision tree and common workflows
- New `plugin-dev-guide` command for autocomplete discoverability (workaround for [#18949](https://github.com/anthropics/claude-code/issues/18949))
- Updates skill count to 10 in manifests

## Changes

| File | Purpose |
|------|---------|
| `skills/plugin-dev-guide/SKILL.md` | Meta-skill with routing logic (972 words) |
| `commands/plugin-dev-guide.md` | Command wrapper for slash menu visibility |
| `plugin.json` | Updated description (10 skills) |
| `marketplace.json` | Updated description (10 skills) |

## Test plan

- [ ] Load plugin locally: `claude plugin marketplace remove plugin-dev-marketplace; claude plugin marketplace add ./; claude plugin install plugin-dev; claude -d`
- [ ] Verify `/plugin-dev:plugin-dev-guide` appears in autocomplete
- [ ] Test routing: `/plugin-dev:plugin-dev-guide how do I add a hook?`
- [ ] Test overview: `/plugin-dev:plugin-dev-guide` (no args)

Closes #184