### PR TITLE
fix: update plugin author metadata to match marketplace owner

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/sjnims"
   },
   "metadata": {
-    "description": "Unofficial plugin-dev plugin marketplace for plugin-dev Claude Code plugin - the plugin itself was initially created by Daisy Hollman at Anthropic.",
+    "description": "Unofficial plugin-dev plugin marketplace. Originally created by Daisy Hollman at Anthropic, now maintained by Steve Nims.",
     "version": "0.3.2"
   },
   "plugins": [
@@ -14,9 +14,8 @@
       "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 9 expert skills covering hooks, MCP integration, LSP servers, commands, agents, marketplaces, and best practices. AI-assisted plugin creation and validation.",
       "version": "0.3.2",
       "author": {
-        "name": "Daisy Hollman",
-        "url": "https://github.com/anthropics/claude-code/",
-        "email": "daisy@anthropic.com"
+        "name": "Steve Nims",
+        "url": "https://github.com/sjnims"
       },
       "homepage": "https://github.com/sjnims/plugin-dev",
       "tags": [

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "version": "0.3.2",
   "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 9 expert skills covering hooks, MCP integration, LSP servers, commands, agents, marketplaces, and best practices. AI-assisted plugin creation and validation.",
   "author": {
-    "name": "Daisy Hollman",
-    "email": "daisy@anthropic.com"
+    "name": "Steve Nims",
+    "url": "https://github.com/sjnims"
   },
   "homepage": "https://github.com/sjnims/plugin-dev",
   "repository": "https://github.com/sjnims/plugin-dev",


### PR DESCRIPTION
** UPDATE **

Turns out local stale data issue. Keeping PR open as I believe this is valid housekeeping.

## Summary

- Update plugin.json and marketplace.json author fields from Daisy Hollman to Steve Nims
- Remove stale reference to `claude-plugins-official` repository in README
- Marketplace description now acknowledges both original author and current maintainer

## Problem

The plugin installation shows an error:
```
Plugin 'plugin-dev' not found in marketplace 'claude-plugins-official'
→ Plugin may not exist in marketplace 'claude-plugins-official'
```

This happens because the author metadata still referenced Anthropic infrastructure, causing Claude Code to look for the plugin in the wrong marketplace.
<img width="923" height="508" alt="Screenshot 2026-01-26 at 1 39 35 PM" src="https://github.com/user-attachments/assets/70b7e443-b522-4d8a-9d71-51b2a20e7888" />

## Test plan

- [ ] Reinstall plugin and verify no `claude-plugins-official` error appears
- [ ] Verify plugin loads correctly with updated metadata